### PR TITLE
A way to tell the user that some files failed to download, when they do, and an option to try again if they do, or Continue

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ $ WINEPREFIX=<wine prefix> ./truckersmp-cli <path to your ETS2 install folder>
 
 the `WINEPREFIX` is only mandatory if you are not using the standard `~/.wine/`
 
+If you're having problems using this, and are getting Connection Refused Errors, try the following fix:
+1. Go into /etc/hosts
+2. Add the following line: `104.24.114.213    download.ets2mp.com`
+3. Save, and try it again
+
 ## Install ##
 
 Just clone this repository wherever you want your TruckersMP installation to be.
@@ -36,3 +41,5 @@ I was greatly inspired by mewrev's [Inject](https://github.com/mewrev/inject) to
 and TheUnknownNO's unofficial [TruckersMP-Launcher](https://github.com/TheUnknownNO/TruckersMP-Launcher).
 
 Amit Malik's [article](http://securityxploded.com/dll-injection-and-hooking.php) on dll injection was also a great help.
+Gnabbist on YouTube for finding the /etc/hosts fix
+ferenCEO for mentioning it here

--- a/README.md
+++ b/README.md
@@ -41,5 +41,7 @@ I was greatly inspired by mewrev's [Inject](https://github.com/mewrev/inject) to
 and TheUnknownNO's unofficial [TruckersMP-Launcher](https://github.com/TheUnknownNO/TruckersMP-Launcher).
 
 Amit Malik's [article](http://securityxploded.com/dll-injection-and-hooking.php) on dll injection was also a great help.
+
 Gnabbist on YouTube for finding the /etc/hosts fix
+
 ferenCEO for mentioning it here

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ the `WINEPREFIX` is only mandatory if you are not using the standard `~/.wine/`
 
 If you're having problems using this, and are getting Connection Refused Errors, try the following fix:
 1. Go into /etc/hosts
-2. Add the following line: `104.24.114.213    download.ets2mp.com` (Be warned, there has to be 4 spaces there, instead of the one GitHub shortened it to)
+2. Add the following line: `104.24.114.213    download.ets2mp.com`
 3. Save, and try it again
 
 ## Install ##

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ the `WINEPREFIX` is only mandatory if you are not using the standard `~/.wine/`
 
 If you're having problems using this, and are getting Connection Refused Errors, try the following fix:
 1. Go into /etc/hosts
-2. Add the following line: `104.24.114.213    download.ets2mp.com` (Be warned, there's 4 spaces there)
+2. Add the following line: `104.24.114.213    download.ets2mp.com` (Be warned, there has to be 4 spaces there, instead of the one GitHub shortened it to)
 3. Save, and try it again
 
 ## Install ##

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ the `WINEPREFIX` is only mandatory if you are not using the standard `~/.wine/`
 
 If you're having problems using this, and are getting Connection Refused Errors, try the following fix:
 1. Go into /etc/hosts
-2. Add the following line: `104.24.114.213    download.ets2mp.com`
+2. Add the following line: `104.24.114.213    download.ets2mp.com` (Be warned, there's 4 spaces there)
 3. Save, and try it again
 
 ## Install ##

--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -24,9 +24,23 @@ for f in $files; do
     echo "f = $f"
     mkdir -p "./$dldir/$(dirname $f)"
     wget -O - $dlurl/$f > "./$dldir/$f"
+    if [ ! $? -eq 0 ]; then
+        errors=1
+    fi
 done
 
 rm -f "./.checksums"
+
+if [ ! -z $errors ] && [ "$errors" = "1" ]; then
+    read -p "Some Errors Occured during the Downloading of Files, Continue or Try Again? [C/T]" $userinp1
+    if [ "$userinp1" = "C" ] || [ "$userinp1" = "c" ] || [ "$userinp1" = "Continue" ] || [ "$userinp1" = "continue" ]; then
+    else
+        rm -rf "./truckersmp" "./files.json"
+        #Relaunch to try again
+        "$0"
+        exit 0
+    fi
+fi
 
 echo ""
 echo "###################################################################"

--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -32,12 +32,13 @@ done
 rm -f "./.checksums"
 
 if [ ! -z $errors ] && [ "$errors" = "1" ]; then
-    read -p "Some Errors Occured during the Downloading of Files, Continue or Try Again? [C/T]" $userinp1
-    if [ "$userinp1" = "C" ] || [ "$userinp1" = "c" ] || [ "$userinp1" = "Continue" ] || [ "$userinp1" = "continue" ]; then
+    zenity --question --icon-name=dialog-error --title "Truckers MP CLI" --text "Some Errors Occured during the Downloading of Files, Continue or Try Again?" --ok-label="Continue" --cancel-label="Try Again" --default-cancel
+    if [ $? = 0 ]; then
+        echo "Continuing..."
     else
         rm -rf "./truckersmp" "./files.json"
         #Relaunch to try again
-        "$0"
+        "$0" "$@"
         exit 0
     fi
 fi


### PR DESCRIPTION
Basically, what the title says, though, this implementation will then require 'zenity', which comes with most distros anyway, as I tried using 'read', and that didn't want to catch user input.