### PR TITLE
Checks for steam installation

### DIFF
--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -394,11 +394,11 @@ check_error() {
         fi
 
         # check for steam installation
-        if [ "$proton" = true ] && ! [ -e "$steamdir/steam.sh" ]; then
+        if [ "$proton" = true ] && ! [ -x "$steamdir/steam.sh" ]; then
             # Steam not found in $steamdir, let's try some other possible paths:
 
             # Legacy $HOME/.steam/steam should be a symlink to the steam installation:
-            if [ "$proton" = true ] && [ -e "$HOME/.steam/steam/steam.sh" ]; then
+            if [ -x "$HOME/.steam/steam/steam.sh" ]; then
                 steamdir="$HOME/.steam/steam"
 
             # "This is a new installation, so use a distinct directory to avoid
@@ -406,8 +406,7 @@ check_error() {
             # Debian uses a subdirectory of ~/.steam, to avoid having a mixture
             # of XDG basedirs and traditional dotfiles in the same application."
             # Debian uses $HOME/.steam/debian-installation
-            elif [ "$proton" = true ] && \
-                 [ -e "$HOME/.steam/debian-installation/steam.sh" ]; then
+            elif [ -x "$HOME/.steam/debian-installation/steam.sh" ]; then
                 steamdir="$HOME/.steam/debian-installation"
 
             # "The historical Debian behaviour has been to use ~/.steam as the
@@ -416,7 +415,7 @@ check_error() {
             # from that, but we can't easily disentangle this in existing
             # installations."
             # ~/.steam is the really old legacy path but can still be used
-            elif [ "$proton" = true ] && [ -e "$HOME/.steam/steam.sh" ]; then
+            elif [ -x "$HOME/.steam/steam.sh" ]; then
                 steamdir="$HOME/.steam"
             else
                 >&2 echo "Unable to locate your steam installation."
@@ -457,8 +456,8 @@ check_error() {
     print "prefixdir: $prefixdir"
     if [ "$proton" = true ]; then
         print "protondir: $protondir"
+        print "steamdir: $steamdir"
     fi
-    print "steamdir: $steamdir"
 }
 
 {   # https://stackoverflow.com/a/14203146

--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -395,16 +395,32 @@ check_error() {
 
         # check for steam installation
         if [ "$proton" = true ] && ! [ -e "$steamdir/steam.sh" ]; then
-            print "Didn't found steam in $steamdir"
+            # Steam not found in $steamdir, let's try some other possible paths:
 
-            # debian based systems are using a special different location for steam
-            # let's try steams legacy path
-            if [ "$proton" = true ] && ! [ -e "$HOME/.steam/steam/steam.sh" ]; then
-                >&2 echo "Unable to locate the steam installation."
-                quit 1
-            else
+            # Legacy $HOME/.steam/steam should be a symlink to the steam installation:
+            if [ "$proton" = true ] && [ -e "$HOME/.steam/steam/steam.sh" ]; then
                 steamdir="$HOME/.steam/steam"
-                print "found steam in $steamdir"
+
+            # "This is a new installation, so use a distinct directory to avoid
+            # file collisions. Valve would use $XDG_DATA_HOME/Steam here.
+            # Debian uses a subdirectory of ~/.steam, to avoid having a mixture
+            # of XDG basedirs and traditional dotfiles in the same application."
+            # Debian uses $HOME/.steam/debian-installation
+            elif [ "$proton" = true ] && \
+                 [ -e "$HOME/.steam/debian-installation/steam.sh" ]; then
+                steamdir="$HOME/.steam/debian-installation"
+
+            # "The historical Debian behaviour has been to use ~/.steam as the
+            # installation directory in addition to using it as the control
+            # directory.This causes some file collisions, so we've moved away
+            # from that, but we can't easily disentangle this in existing
+            # installations."
+            # ~/.steam is the really old legacy path but can still be used
+            elif [ "$proton" = true ] && [ -e "$HOME/.steam/steam.sh" ]; then
+                steamdir="$HOME/.steam"
+            else
+                >&2 echo "Unable to locate your steam installation."
+                quit 1
             fi
         fi
     fi

--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -20,6 +20,7 @@ scriptdir=$(dirname "$(realpath "$0")")
 
 # non changeable dirs
 steamcmddir="$XDG_CACHE_HOME/truckersmp-cli/steamcmd"
+steamdir="$XDG_DATA_HOME/Steam"
 
 # files
 filelist=$(mktemp -t truckersmp-cli.XXXXXXXXXX)
@@ -121,7 +122,7 @@ start_with_proton() {
         # Wait for user login
         if command -v inotifywait > /dev/null 2>&1; then
             print "Waiting for Steam using inotifywait."
-            inotifywait -e modify -qq "$XDG_DATA_HOME/Steam/config/loginusers.vdf"
+            inotifywait -e modify -qq "$steamdir/config/loginusers.vdf"
             print "Steam should now be up and running and the user logged in."
         else
             # fallback to 30 seconds if inotify-tools is not installed
@@ -141,7 +142,7 @@ start_with_proton() {
     print   "SteamGameId=$steamid" \
             "SteamAppId=$steamid" \
             "STEAM_COMPAT_DATA_PATH=$prefixdir" \
-            "STEAM_COMPAT_CLIENT_INSTALL_PATH=$XDG_DATA_HOME/Steam" \
+            "STEAM_COMPAT_CLIENT_INSTALL_PATH=$steamdir" \
             "/usr/bin/env python3 $protondir/proton" \
             "run" \
             "$scriptdir/truckersmp-cli.exe $gamedir $moddir"
@@ -149,7 +150,7 @@ start_with_proton() {
     SteamGameId="$steamid" \
     SteamAppId="$steamid" \
     STEAM_COMPAT_DATA_PATH="$prefixdir" \
-    STEAM_COMPAT_CLIENT_INSTALL_PATH="$XDG_DATA_HOME/Steam" \
+    STEAM_COMPAT_CLIENT_INSTALL_PATH="$steamdir" \
     /usr/bin/env python3    "$protondir/proton" \
                             run \
                             "$scriptdir/truckersmp-cli.exe" \
@@ -391,6 +392,21 @@ check_error() {
                 prefixdir="$prefixdir/pfx"
             fi
         fi
+
+        # check for steam installation
+        if [ "$proton" = true ] && ! [ -e "$steamdir/steam.sh" ]; then
+            print "Didn't found steam in $steamdir"
+
+            # debian based systems are using a special different location for steam
+            # let's try steams legacy path
+            if [ "$proton" = true ] && ! [ -e "$HOME/.steam/steam/steam.sh" ]; then
+                >&2 echo "Unable to locate the steam installation."
+                quit 1
+            else
+                steamdir="$HOME/.steam/steam"
+                print "found steam in $steamdir"
+            fi
+        fi
     fi
 
     # checks for starting while not updating
@@ -426,6 +442,7 @@ check_error() {
     if [ "$proton" = true ]; then
         print "protondir: $protondir"
     fi
+    print "steamdir: $steamdir"
 }
 
 {   # https://stackoverflow.com/a/14203146


### PR DESCRIPTION
Try legacy paths if steam isn't found at `$XDG_DATA_HOME/Steam`:
- `$HOME/.steam/steam`
- `$HOME/.steam/debian-installation`
- `$HOME/.steam`

Hopefully this fixes #32 until the python port is ready.