### PR TITLE
Use Proton 4.11 as default and enable D9VK

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ When using standard Wine you should start the windows version of Steam first.
                   Default: <i>$XDG_DATA_HOME/truckersmp-cli/$GAME/data</i>
     -i <i>appid</i>    Choose a different appid for Proton
                   Needs an update for changes.
-                  Proton 4.2:	      <i>1054830</i> (Default)
+                  Proton 4.11:      <i>1113280</i> (Default)
+                  Proton 4.2:       <i>1054830</i>
                   Proton 3.16 Beta: <i>996510</i>
                   Proton 3.16:      <i>961940</i>
                   Proton 3.7 Beta:  <i>930400</i>

--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -28,7 +28,7 @@ checksums=$(mktemp -t truckersmp-cli.XXXXXXXXXX)
 # variables
 appid_ats="270880"      # https://steamdb.info/app/270880/
 appid_ets2="227300"     # https://steamdb.info/app/227300/
-appid_proton="1054830"  # Proton 4.2 https://steamdb.info/app/1054830/
+appid_proton="1113280"  # Proton 4.11 https://steamdb.info/app/1113280/
 ats=false
 ets2=false
 proton=false
@@ -71,7 +71,8 @@ cat <<HELP_USAGE
                   Default: \$XDG_DATA_HOME/truckersmp-cli/\$GAME/data
     -i appid    Choose a different appid for Proton
                   Needs an update for changes.
-                  Proton 4.2:       1054830 (Default)
+                  Proton 4.11:      1113280 (Default)
+                  Proton 4.2:       1054830
                   Proton 3.16 Beta: 996510
                   Proton 3.16:      961940
                   Proton 3.7 Beta:  930400
@@ -148,6 +149,7 @@ start_with_proton() {
 
     SteamGameId="$steamid" \
     SteamAppId="$steamid" \
+    PROTON_USE_D9VK=1 \
     STEAM_COMPAT_DATA_PATH="$prefixdir" \
     STEAM_COMPAT_CLIENT_INSTALL_PATH="$XDG_DATA_HOME/Steam" \
     /usr/bin/env python3    "$protondir/proton" \


### PR DESCRIPTION
Proton has now D9VK built in and while I couldn't get it to work manually with TruckersMP before it now works with this built in.
In my short test I was able to set the graphics preset two steps higher from _low_ to _high_ and get around the same framerate. Be sure to restart the game after changing the settings because I got even worse framerates without doing so.