### PR TITLE
Add GitHub Actions workflow files

### DIFF
--- a/.github/workflows/build_and_upload_inject_program.yaml
+++ b/.github/workflows/build_and_upload_inject_program.yaml
@@ -1,0 +1,36 @@
+name: Inject program
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - .github/workflows/build_and_upload_inject_program.yaml
+      - truckersmp-cli.c
+  pull_request:
+    branches:
+      - master
+    paths:
+      - .github/workflows/build_and_upload_inject_program.yaml
+      - truckersmp-cli.c
+
+jobs:
+  build_and_upload_inject_program:
+    name: Build and upload inject program
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install gcc-mingw-w64-x86-64
+        run: |
+             sudo apt -q update
+             sudo apt -q install --no-install-recommends gcc-mingw-w64-x86-64
+      - name: Build truckersmp-cli.exe
+             # we need "make clean" because we already have truckersmp-cli.exe
+             # and "make" does nothing even when truckersmp-cli.c is changed
+        run: make clean && make
+      - name: Strip truckersmp-cli.exe
+        run: x86_64-w64-mingw32-strip truckersmp-cli.exe
+      - uses: actions/upload-artifact@v1
+        with:
+          name: ${{ github.event_name }}-${{ github.sha }}
+          path: truckersmp-cli.exe

--- a/.github/workflows/check_main_script.yaml
+++ b/.github/workflows/check_main_script.yaml
@@ -1,0 +1,29 @@
+name: Main script
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - .github/workflows/check_main_script.yaml
+      - truckersmp-cli
+  pull_request:
+    branches:
+      - master
+    paths:
+      - .github/workflows/check_main_script.yaml
+      - truckersmp-cli
+
+jobs:
+  check_by_flake8:
+    name: Check main script by flake8
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
+      - name: Install flake8, flake8-docstrings, and flake8-import-order
+        run: pip install flake8 flake8-docstrings flake8-import-order
+      - name: Check main script by flake8
+        run: flake8 --max-line-length=90 --show-source --statistics truckersmp-cli

--- a/.github/workflows/check_proton_json.yaml
+++ b/.github/workflows/check_proton_json.yaml
@@ -1,0 +1,50 @@
+name: proton.json
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - .github/workflows/check_proton_json.yaml
+      - proton.json
+  pull_request:
+    branches:
+      - master
+    paths:
+      - .github/workflows/check_proton_json.yaml
+      - proton.json
+
+jobs:
+  check_proton_json:
+    name: Check proton.json
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
+      - name: Generate Proton AppId list from proton.json
+        run: |
+             import json
+             import sys
+             with open("proton.json") as f:
+                 proton = json.load(f)
+                 try:
+                     default_is_valid = False
+                     epilog = "Proton AppId list:\n"
+                     for k, v in proton.items():
+                         default_mark = ""
+                         if k == proton["default"]:
+                             default_mark += " (Default)"
+                             default_is_valid = True
+                         if k != "default":
+                             epilog += "    Proton {:13}: {:>10}{}\n".format(
+                               k, v, default_mark)
+                     print(epilog, end="")
+                 except KeyError:
+                     sys.exit(
+                       "** Default version is undefined **\n> {}".format(proton))
+                 if not default_is_valid:
+                     sys.exit(
+                       "** Default version is invalid **\n> {}".format(proton))
+        shell: python


### PR DESCRIPTION
This PR adds GitHub Actions workflow file. *This doesn't change programs* but is useful for improving productivity.

This allows us to do some checks automatically when:

* new commits are pushed to `master` branch
* someone created a new PR against `master` branch

Currently it checks:

* `proton.json`
    * Job name: `proton_json`
        * Generate Proton AppId list from `proton.json`
        * Check whether `proton.json` is valid
* `truckersmp-cli`
    * Job name: `download_files`
        * Check whether `download_files()` function works properly
        * HTTP redirection handling is also tested
    * Job name: `flake8`
        * Check main script by flake8 with flake8-docstrings and flake8-import-order
* `truckersmp-cli.c`
    * Job name: `build`
        * Compile C source by mingw-w64
        * Create binary .tar.xz files (GitHub Actions "Artifact" file)

These jobs run in parallel.