### PR TITLE
Add function to retrieve current supported versions

### DIFF
--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -473,7 +473,7 @@ Please report an issue: {}""".format(e, URL.issueurl))
 
 
 def get_supported_game_versions():
-    """Returns a dict of game - version pairs"""
+    """Return a dict of game - version pairs."""
     # {
     #     "truckersmp": "0.2.2.6.6",
     #     "ets2": "1.36.2.55",

--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -472,12 +472,15 @@ Please report an issue: {}""".format(e, URL.issueurl))
 
 
 def get_supported_game_versions():
-    """Get TruckersMP-supported game versions via TruckersMP Web API."""
-    # Returns a dict of 'game: version' pairs:
-    # {
-    #     "ets2": "1.36.2.55",
-    #     "ats": "1.36.1.40"
-    # }
+    """
+    Get TruckersMP-supported game versions via TruckersMP Web API.
+
+    Returns a dict of 'game: version' pairs:
+    {
+        "ets2": "1.36.2.55",
+        "ats": "1.36.1.40"
+    }
+    """
     try:
         with urllib.request.urlopen(URL.truckersmp_api) as f:
             data = json.load(f)

--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -14,7 +14,6 @@ import json
 import locale
 import logging
 import os
-import re
 import shutil
 import signal
 import subprocess as subproc

--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -14,6 +14,7 @@ import json
 import locale
 import logging
 import os
+import re
 import shutil
 import signal
 import subprocess as subproc
@@ -36,6 +37,7 @@ class URL:
     steamcmdurl = "https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz"
     raw_github = "raw.githubusercontent.com"
     d3dcompilerpath = "/ImagingSIMS/ImagingSIMS/master/Redist/x64/d3dcompiler_47.dll"
+    truckersmp_api = "https://api.truckersmp.com/v2"
 
 
 class Dir:
@@ -468,6 +470,30 @@ Please report an issue: {}""".format(e, URL.issueurl))
         if not download_files(URL.dlurlalt, dlfiles):
             # something went wrong
             sys.exit("Failed to download mod files.")
+
+
+def get_supported_game_versions():
+    """Returns a dict of game - version pairs"""
+    # {
+    #     "truckersmp": "0.2.2.6.6",
+    #     "ets2": "1.36.2.55",
+    #     "ats": "1.36.1.40"
+    # }
+    try:
+        with urllib.request.urlopen(URL.truckersmp_api + "/version") as f:
+            data = json.loads(f.read())
+    except Exception:
+        return {}
+
+    answer = {}
+    pattern = r"[\D]+$"
+    if "name" in data:
+        answer["truckersmp"] = re.sub(pattern, "", data["name"])
+    if "supported_game_version" in data:
+        answer["ets2"] = re.sub(pattern, "", data["supported_game_version"])
+    if "supported_ats_game_version" in data:
+        answer["ats"] = re.sub(pattern, "", data["supported_ats_game_version"])
+    return answer
 
 
 def update_game():

--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -36,6 +36,7 @@ class URL:
     steamcmdurl = "https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz"
     raw_github = "raw.githubusercontent.com"
     d3dcompilerpath = "/ImagingSIMS/ImagingSIMS/master/Redist/x64/d3dcompiler_47.dll"
+    truckersmp_api = "https://api.truckersmp.com/v2/version"
 
 
 class Dir:
@@ -478,7 +479,7 @@ def get_supported_game_versions():
     #     "ats": "1.36.1.40"
     # }
     try:
-        with urllib.request.urlopen("https://api.truckersmp.com/v2/version") as f:
+        with urllib.request.urlopen(URL.truckersmp_api) as f:
             data = json.load(f)
 
         return {

--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -481,17 +481,14 @@ def get_supported_game_versions():
     # }
     try:
         with urllib.request.urlopen(URL.truckersmp_api + "/version") as f:
-            data = json.loads(f.read())
-    except Exception:
-        return {}
+            data = json.load(f)
 
-    answer = {}
-    pattern = r"[\D]+$"
-    if "supported_game_version" in data:
-        answer["ets2"] = re.sub(pattern, "", data["supported_game_version"])
-    if "supported_ats_game_version" in data:
-        answer["ats"] = re.sub(pattern, "", data["supported_ats_game_version"])
-    return answer
+        return {
+            "ets2": data["supported_game_version"].replace("s", ""),
+            "ats": data["supported_ats_game_version"].replace("s", "")
+        }
+    except Exception:
+        pass
 
 
 def update_game():

--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -473,7 +473,8 @@ Please report an issue: {}""".format(e, URL.issueurl))
 
 
 def get_supported_game_versions():
-    """Return a dict of game - version pairs."""
+    """Get TruckersMP-supported game versions via TruckersMP Web API."""
+    # Returns a dict of 'game: version' pairs:
     # {
     #     "ets2": "1.36.2.55",
     #     "ats": "1.36.1.40"

--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -475,7 +475,6 @@ Please report an issue: {}""".format(e, URL.issueurl))
 def get_supported_game_versions():
     """Return a dict of game - version pairs."""
     # {
-    #     "truckersmp": "0.2.2.6.6",
     #     "ets2": "1.36.2.55",
     #     "ats": "1.36.1.40"
     # }
@@ -487,8 +486,6 @@ def get_supported_game_versions():
 
     answer = {}
     pattern = r"[\D]+$"
-    if "name" in data:
-        answer["truckersmp"] = re.sub(pattern, "", data["name"])
     if "supported_game_version" in data:
         answer["ets2"] = re.sub(pattern, "", data["supported_game_version"])
     if "supported_ats_game_version" in data:

--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -487,7 +487,7 @@ def get_supported_game_versions():
             "ats": data["supported_ats_game_version"].replace("s", "")
         }
     except Exception:
-        pass
+        return None
 
 
 def update_game():

--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -37,7 +37,6 @@ class URL:
     steamcmdurl = "https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz"
     raw_github = "raw.githubusercontent.com"
     d3dcompilerpath = "/ImagingSIMS/ImagingSIMS/master/Redist/x64/d3dcompiler_47.dll"
-    truckersmp_api = "https://api.truckersmp.com/v2"
 
 
 class Dir:
@@ -480,7 +479,7 @@ def get_supported_game_versions():
     #     "ats": "1.36.1.40"
     # }
     try:
-        with urllib.request.urlopen(URL.truckersmp_api + "/version") as f:
+        with urllib.request.urlopen("https://api.truckersmp.com/v2/version") as f:
             data = json.load(f)
 
         return {


### PR DESCRIPTION
As mentioned in #58 this is probably the easiest way to get the currently supported game versions.

It [queries the API](https://api.truckersmp.com/v2/version) and filters for relevant information.

Returns a dict of game-version pairs:
~~~
{
    "truckersmp": "0.2.2.6.6",
    "ets2": "1.36.2.55",
    "ats": "1.36.1.40"
}
~~~