### PR TITLE
SDL2 run-time checking and README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,11 @@ $ ./truckersmp-cli -esw -x "/path/to/prefix/pfx"
 
 * `python3` 3.3 (released in September 2012) or later
 * `steam` either the native Linux version in use with Proton or the Windows Steam in use with Wine
+* x86_64 version of SDL2 library
+    * `libsdl2-2.0-0` on Debian-based systems
+    * `media-libs/libsdl2` on Gentoo Linux
+    * `sdl2` on Arch Linux
+    * `SDL2` on RPM-based systems
 
 ### Optional
 

--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -7,6 +7,7 @@ This script downloads/updates games and starts games with Wine/Proton.
 """
 
 import argparse
+import ctypes
 import hashlib
 import http.client
 import io
@@ -14,6 +15,7 @@ import json
 import locale
 import logging
 import os
+import platform
 import shutil
 import signal
 import subprocess as subproc
@@ -79,6 +81,7 @@ class File:
     overlayrenderer_inner = "ubuntu12_64/gameoverlayrenderer.so"
     d3dcompiler_47 = os.path.join(Dir.dllsdir, "d3dcompiler_47.dll")
     d3dcompiler_47_md5 = "b2cc65e1930e75f563078c6a20221b37"
+    sdl2_soname = "libSDL2-2.0.so.0"
 
 
 class AppId:
@@ -89,6 +92,25 @@ class AppId:
         "ets2":         227300,        # https://steamdb.info/app/227300/
     }
     proton = {}
+
+
+def check_libsdl2():
+    """
+    Check whether SDL2 shared object file is present.
+
+    If SDL2 is detected, this function returns True.
+    Otherwise, this returns False.
+
+    Currently the check is done only on Linux systems.
+    """
+    if platform.system() != "Linux":
+        return True
+
+    try:
+        ctypes.cdll.LoadLibrary(File.sdl2_soname)
+        return True
+    except OSError:
+        return False
 
 
 def download_files(host, files_to_download, progress_count=None):
@@ -784,6 +806,8 @@ if __name__ == "__main__":
 
     # start truckersmp with proton or wine
     if args.start:
+        if not check_libsdl2():
+            sys.exit("SDL2 was not found on your system.")
         start_functions = (("Proton", start_with_proton), ("Wine", start_with_wine))
         i = 0 if args.proton else 1
         compat_tool, start_game = start_functions[i]


### PR DESCRIPTION
Closes #60 and #36.

* Check x86_64 version of libSDL2 on Linux
* README.md: Add "x86_64 version of SDL2" to "Dependencies > Required"