### PR TITLE
Automatic branch detection

### DIFF
--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -99,7 +99,7 @@ class DowngradeHTMLParser(html.parser.HTMLParser):
     """Extract downgrade information from HTML code at stats.truckersmp.com."""
 
     _data = {}
-    _downgrade_flag = False
+    _is_downgrade_node = False
 
     def handle_starttag(self, tag, attrs):
         """HTML start tag handler."""
@@ -107,16 +107,16 @@ class DowngradeHTMLParser(html.parser.HTMLParser):
             if (attr[0] == "href"
                     and len(attr) > 1
                     and attr[1] == URL.truckersmp_downgrade_help):
-                self._downgrade_flag = True
+                self._is_downgrade_node = True
                 break
 
     def handle_endtag(self, tag):
         """HTML end tag handler."""
-        self._downgrade_flag = False
+        self._is_downgrade_node = False
 
     def handle_data(self, data):
         """HTML data handler."""
-        if self._downgrade_flag:
+        if self._is_downgrade_node:
             if "ETS2" in data:
                 self._data["ets2"] = True
             if "ATS" in data:

--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -98,7 +98,7 @@ class AppId:
 class DowngradeHTMLParser(html.parser.HTMLParser):
     """Extract downgrade information from HTML code at stats.truckersmp.com."""
 
-    _data = {}
+    _data = {"ets2": False, "ats": False}
     _is_downgrade_node = False
 
     def handle_starttag(self, tag, attrs):

--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -39,6 +39,7 @@ class URL:
     d3dcompilerpath = "/ImagingSIMS/ImagingSIMS/master/Redist/x64/d3dcompiler_47.dll"
     truckersmp_api = "https://api.truckersmp.com/v2/version"
     truckersmp_stats = "https://stats.truckersmp.com"
+    truckersmp_downgrade_help = "https://truckersmp.com/kb/26"
 
 
 class Dir:
@@ -105,7 +106,7 @@ class DowngradeHTMLParser(html.parser.HTMLParser):
         for attr in attrs:
             if (attr[0] == "href"
                     and len(attr) > 1
-                    and attr[1] == "https://truckersmp.com/kb/26"):
+                    and attr[1] == URL.truckersmp_downgrade_help):
                 self._downgrade_flag = True
                 break
 

--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -605,7 +605,7 @@ def update_game():
            "+app_update", str(args.proton_appid), "validate",
            "+quit"])
 
-    branch = ""
+    branch = "public"
     if args.beta:
         branch = args.beta
     else:
@@ -621,22 +621,19 @@ def update_game():
     +@sSteamCmdForcePlatformType windows
     +login {}
     +force_install_dir {}
-    +app_update {}{} validate
+    +app_update {} -beta {} validate
     +quit""".format(
-      steamcmd, args.account, args.gamedir, args.steamid,
-      " -beta {}".format(branch) if branch else ""))
+      steamcmd, args.account, args.gamedir, args.steamid, branch))
     cmdline = [
         steamcmd,
         "+@sSteamCmdForcePlatformType", "windows",
         "+login", args.account,
         "+force_install_dir", args.gamedir,
         "+app_update", args.steamid,
+        "-beta", branch,
+        "validate",
+        "+quit"
     ]
-    if branch:
-        cmdline.append("-beta")
-        cmdline.append(branch)
-    cmdline.append("validate")
-    cmdline.append("+quit")
     subproc.call(cmdline)
 
 

--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -95,7 +95,7 @@ class AppId:
 
 
 class DowngradeHTMLParser(html.parser.HTMLParser):
-    """Extract downgrade information from html."""
+    """Extract downgrade information from HTML code at stats.truckersmp.com."""
 
     _data = {}
     _downgrade_flag = False
@@ -510,16 +510,20 @@ def get_beta_branch_name(game_name="ets2"):
     """
     Get the current required beta branch name to comply with TruckersMP.
 
-    Returns a string containing the name (eg. "temporary_1_36") or None
+    If downgrade is needed, this returns a branch name that can be used
+    to install TruckersMP-compatible versions of games (e.g. "temporary_1_36")
+    on success or None on error.
+    If downgrade is not needed, this returns None.
     """
     try:
         parser = DowngradeHTMLParser()
         with urllib.request.urlopen(URL.truckersmp_stats) as f:
             parser.feed(f.read().decode("utf-8"))
 
-        if parser.data[game_name] is True:
-            version = get_supported_game_versions()[game_name].split('.')
+        if parser.data[game_name]:
+            version = get_supported_game_versions()[game_name].split(".")
             return "temporary_{}_{}".format(version[0], version[1])
+        return None
     except Exception:
         return None
 
@@ -600,12 +604,14 @@ def update_game():
            "+app_update", str(args.proton_appid), "validate",
            "+quit"])
 
-    game = "ats" if args.ats else "ets2"
     branch = ""
-    if not args.beta and get_beta_branch_name(game) is not None:
-        branch = get_beta_branch_name(game)
-    elif args.beta:
+    if args.beta:
         branch = args.beta
+    else:
+        game = "ats" if args.ats else "ets2"
+        beta_branch_name = get_beta_branch_name(game)
+        if beta_branch_name:
+            branch = beta_branch_name
 
     # use steamcmd to update the chosen game
     logging.debug("Updating Game (AppId:{})".format(args.steamid))

--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -8,6 +8,7 @@ This script downloads/updates games and starts games with Wine/Proton.
 
 import argparse
 import hashlib
+import html.parser
 import http.client
 import io
 import json
@@ -37,6 +38,7 @@ class URL:
     raw_github = "raw.githubusercontent.com"
     d3dcompilerpath = "/ImagingSIMS/ImagingSIMS/master/Redist/x64/d3dcompiler_47.dll"
     truckersmp_api = "https://api.truckersmp.com/v2/version"
+    truckersmp_stats = "https://stats.truckersmp.com"
 
 
 class Dir:
@@ -90,6 +92,39 @@ class AppId:
         "ets2":         227300,        # https://steamdb.info/app/227300/
     }
     proton = {}
+
+
+class DowngradeHTMLParser(html.parser.HTMLParser):
+    """Extract downgrade information from html."""
+
+    _data = {}
+    _downgrade_flag = False
+
+    def handle_starttag(self, tag, attrs):
+        """HTML start tag handler."""
+        for attr in attrs:
+            if (attr[0] == "href"
+                    and len(attr) > 1
+                    and attr[1] == "https://truckersmp.com/kb/26"):
+                self._downgrade_flag = True
+                break
+
+    def handle_endtag(self, tag):
+        """HTML end tag handler."""
+        self._downgrade_flag = False
+
+    def handle_data(self, data):
+        """HTML data handler."""
+        if self._downgrade_flag:
+            if "ETS2" in data:
+                self._data["ets2"] = True
+            if "ATS" in data:
+                self._data["ats"] = True
+
+    @property
+    def data(self):
+        """Return downgrade information."""
+        return self._data
 
 
 def download_files(host, files_to_download, progress_count=None):
@@ -471,6 +506,24 @@ Please report an issue: {}""".format(e, URL.issueurl))
             sys.exit("Failed to download mod files.")
 
 
+def get_beta_branch_name(game_name="ets2"):
+    """
+    Get the current required beta branch name to comply with TruckersMP.
+
+    Returns a string containing the name (eg. "temporary_1_36") or None
+    """
+    try:
+        parser = DowngradeHTMLParser()
+        with urllib.request.urlopen(URL.truckersmp_stats) as f:
+            parser.feed(f.read().decode("utf-8"))
+
+        if parser.data[game_name] is True:
+            version = get_supported_game_versions()[game_name].split('.')
+            return "temporary_{}_{}".format(version[0], version[1])
+    except Exception:
+        return None
+
+
 def get_supported_game_versions():
     """
     Get TruckersMP-supported game versions via TruckersMP Web API.
@@ -547,6 +600,13 @@ def update_game():
            "+app_update", str(args.proton_appid), "validate",
            "+quit"])
 
+    game = "ats" if args.ats else "ets2"
+    branch = ""
+    if not args.beta and get_beta_branch_name(game) is not None:
+        branch = get_beta_branch_name(game)
+    elif args.beta:
+        branch = args.beta
+
     # use steamcmd to update the chosen game
     logging.debug("Updating Game (AppId:{})".format(args.steamid))
     logging.info("""Command:
@@ -557,7 +617,7 @@ def update_game():
     +app_update {}{} validate
     +quit""".format(
       steamcmd, args.account, args.gamedir, args.steamid,
-      " -beta {}".format(args.beta) if args.beta else ""))
+      " -beta {}".format(branch) if branch else ""))
     cmdline = [
         steamcmd,
         "+@sSteamCmdForcePlatformType", "windows",
@@ -565,9 +625,9 @@ def update_game():
         "+force_install_dir", args.gamedir,
         "+app_update", args.steamid,
     ]
-    if args.beta:
+    if branch:
         cmdline.append("-beta")
-        cmdline.append(args.beta)
+        cmdline.append(branch)
     cmdline.append("validate")
     cmdline.append("+quit")
     subproc.call(cmdline)


### PR DESCRIPTION
This will automatically detect the branch which is needed to get the correct ETS2 or ATS version for being able to run TruckersMP. The branch can still be overwritten by `--branch`.

* `https://stats.truckersmp.com` will be parsed for the downgrade link `https://truckersmp.com/kb/26` and the message scanned for ETS2 and ATS. We may have to revisit this in case they adjust the message.
If there's a better way to get the version we will have _after_ an update or if an downgrade is needed we should also revisit this part.
This is largely based on your [comment](https://github.com/lhark/truckersmp-cli/issues/58#issuecomment-622728329).
* If a downgrade would be needed the currently supported version by TruckersMP will be fetched and guessed into SCS beta branch naming scheme. `temporary_1_36`