### PR TITLE
Auto detect steam account

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ $ ./truckersmp-cli -esw -x "/path/to/prefix/pfx"
 
 * `wine` as a possible replacement to Proton
 * `git` to clone this repo and self update the script
+* [`vdf`][python-vdf] to automatically detect the steam account with saved credentials
 
 ## Install
 
@@ -191,3 +192,5 @@ I was greatly inspired by mewrev's [Inject](https://github.com/mewrev/inject) to
 and TheUnknownNO's unofficial [TruckersMP-Launcher](https://github.com/TheUnknownNO/TruckersMP-Launcher).
 
 Amit Malik's [article](http://securityxploded.com/dll-injection-and-hooking.php) on dll injection was also a great help.
+
+[python-vdf]: https://github.com/ValvePython/vdf

--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -25,6 +25,7 @@ import tarfile
 import time
 import urllib.parse
 import urllib.request
+import vdf
 from getpass import getuser
 from gettext import ngettext
 
@@ -529,6 +530,27 @@ Please report an issue: {}""".format(e, URL.issueurl))
             sys.exit("Failed to download mod files.")
 
 
+def get_current_steam_user():
+    """
+    Get the current AccountName with saved login credentials.
+
+    Returns the found steam login name or None.
+    """
+    for path in File.loginusers_paths:
+        try:
+            login_vdf = vdf.parse(open(path))
+
+            for _, info in login_vdf["users"].items():
+                if info["MostRecent"] == "1" and info["RememberPassword"] == "1":
+                    return info["AccountName"]
+
+        except Exception:
+            pass
+
+    logging.debug("Unable to find logged in user.")
+    return None
+
+
 def get_beta_branch_name(game_name="ets2"):
     """
     Get the current required beta branch name to comply with TruckersMP.
@@ -784,6 +806,7 @@ When using standard Wine you should start the windows version of Steam first.
               Fallback: ./truckersmp]""")
     ap.add_argument(
       "-n", "--account", metavar="NAME", type=str,
+      default=get_current_steam_user(),
       help="""steam account name to use
               (This account should own the game and ideally is logged in
               with saved credentials)""")

--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -25,9 +25,10 @@ import tarfile
 import time
 import urllib.parse
 import urllib.request
-import vdf
 from getpass import getuser
 from gettext import ngettext
+
+import vdf
 
 
 class URL:

--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -552,8 +552,14 @@ def get_current_steam_user():
                 login_vdf = vdf.parse(f)
 
             for info in login_vdf["users"].values():
-                if info["MostRecent"] == "1" and info["RememberPassword"] == "1":
-                    return info["AccountName"]
+                if (("MostRecent" in info and info["MostRecent"] == "1" or
+                    "mostrecent" in info and info["mostrecent"] == "1") and
+                    ("RememberPassword" in info and info["RememberPassword"] == "1" or
+                    "rememberpassword" in info and info["rememberpassword"] == "1")):
+                    if "AccountName" in info:
+                        return info["AccountName"]
+                    if "accountname" in info:
+                        return info["accountname"]
         except Exception:
             pass
     return None

--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -535,7 +535,8 @@ def get_current_steam_user():
     """
     Get the current AccountName with saved login credentials.
 
-    Returns the found steam login name or None.
+    If successful this returns the AccountName of the user with saved credentials.
+    Otherwise this returns None.
     """
     for path in File.loginusers_paths:
         try:
@@ -544,7 +545,6 @@ def get_current_steam_user():
             for _, info in login_vdf["users"].items():
                 if info["MostRecent"] == "1" and info["RememberPassword"] == "1":
                     return info["AccountName"]
-
         except Exception:
             pass
     return None

--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -553,9 +553,10 @@ def get_current_steam_user():
 
             for info in login_vdf["users"].values():
                 if (("MostRecent" in info and info["MostRecent"] == "1" or
-                    "mostrecent" in info and info["mostrecent"] == "1") and
-                    ("RememberPassword" in info and info["RememberPassword"] == "1" or
-                    "rememberpassword" in info and info["rememberpassword"] == "1")):
+                        "mostrecent" in info and info["mostrecent"] == "1") and
+                        ("RememberPassword" in info and info["RememberPassword"] == "1" or
+                            "rememberpassword" in info and
+                            info["rememberpassword"] == "1")):
                     if "AccountName" in info:
                         return info["AccountName"]
                     if "accountname" in info:

--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -547,8 +547,6 @@ def get_current_steam_user():
 
         except Exception:
             pass
-
-    print("** INFO **  Unable to find logged in user automatically.")
     return None
 
 
@@ -735,7 +733,10 @@ Need to download (-u) Proton?""".format(args.protondir))
 
     # checks for updating
     if args.update and not args.account:
-        sys.exit("Need the steam account name (-n name) to update.")
+        args.account = get_current_steam_user()
+        if not args.account:
+            logging.info("Unable to find logged in steam user automatically.")
+            sys.exit("Need the steam account name (-n name) to update.")
 
     # info
     logging.info("AppId/GameId: {} ({})".format(args.steamid, game))
@@ -807,7 +808,6 @@ When using standard Wine you should start the windows version of Steam first.
               Fallback: ./truckersmp]""")
     ap.add_argument(
       "-n", "--account", metavar="NAME", type=str,
-      default=get_current_steam_user(),
       help="""steam account name to use
               (This account should own the game and ideally is logged in
               with saved credentials)""")

--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -542,10 +542,9 @@ def get_current_steam_user():
 
     If successful this returns the AccountName of the user with saved credentials.
     Otherwise this returns None.
-    """
-    if not vdf_is_available:
-        return None
 
+    This function depends on the package "vdf".
+    """
     for path in File.loginusers_paths:
         try:
             with open(path) as f:
@@ -745,7 +744,8 @@ Need to download (-u) Proton?""".format(args.protondir))
 
     # checks for updating
     if args.update and not args.account:
-        args.account = get_current_steam_user()
+        if vdf_is_available:
+            args.account = get_current_steam_user()
         if not args.account:
             logging.info("Unable to find logged in steam user automatically.")
             sys.exit("Need the steam account name (-n name) to update.")

--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -540,9 +540,10 @@ def get_current_steam_user():
     """
     for path in File.loginusers_paths:
         try:
-            login_vdf = vdf.parse(open(path))
+            with open(path) as f:
+                login_vdf = vdf.parse(f)
 
-            for _, info in login_vdf["users"].items():
+            for info in login_vdf["users"].values():
                 if info["MostRecent"] == "1" and info["RememberPassword"] == "1":
                     return info["AccountName"]
         except Exception:

--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -552,15 +552,11 @@ def get_current_steam_user():
                 login_vdf = vdf.parse(f)
 
             for info in login_vdf["users"].values():
-                if (("MostRecent" in info and info["MostRecent"] == "1" or
-                        "mostrecent" in info and info["mostrecent"] == "1") and
-                        ("RememberPassword" in info and info["RememberPassword"] == "1" or
-                            "rememberpassword" in info and
-                            info["rememberpassword"] == "1")):
+                if (("RememberPassword" in info and info["RememberPassword"] == "1") and
+                        ("MostRecent" in info and info["MostRecent"] == "1" or
+                         "mostrecent" in info and info["mostrecent"] == "1")):
                     if "AccountName" in info:
                         return info["AccountName"]
-                    if "accountname" in info:
-                        return info["accountname"]
         except Exception:
             pass
     return None

--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -552,11 +552,11 @@ def get_current_steam_user():
                 login_vdf = vdf.parse(f)
 
             for info in login_vdf["users"].values():
-                if (("RememberPassword" in info and info["RememberPassword"] == "1") and
-                        ("MostRecent" in info and info["MostRecent"] == "1" or
-                         "mostrecent" in info and info["mostrecent"] == "1")):
-                    if "AccountName" in info:
-                        return info["AccountName"]
+                remember = "RememberPassword" in info and info["RememberPassword"] == "1"
+                recent_uc = "MostRecent" in info and info["MostRecent"] == "1"
+                recent_lc = "mostrecent" in info and info["mostrecent"] == "1"
+                if remember and (recent_lc or recent_uc) and "AccountName" in info:
+                    return info["AccountName"]
         except Exception:
             pass
     return None

--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -28,7 +28,12 @@ import urllib.request
 from getpass import getuser
 from gettext import ngettext
 
-import vdf
+vdf_is_available = False
+try:
+    import vdf
+    vdf_is_available = True
+except ImportError:
+    pass
 
 
 class URL:
@@ -538,6 +543,9 @@ def get_current_steam_user():
     If successful this returns the AccountName of the user with saved credentials.
     Otherwise this returns None.
     """
+    if not vdf_is_available:
+        return None
+
     for path in File.loginusers_paths:
         try:
             with open(path) as f:

--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -547,7 +547,7 @@ def get_current_steam_user():
         except Exception:
             pass
 
-    logging.debug("Unable to find logged in user.")
+    print("** INFO **  Unable to find logged in user automatically.")
     return None
 
 


### PR DESCRIPTION
This will auto-detect the most recent steam account with saved credentials.

It's still possible to override the account name and the override is required if we're unable to get the account name automatically.