### PR TITLE
Generate bash/zsh completions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,21 @@
 CC=x86_64-w64-mingw32-gcc
 
-all: truckersmp-cli.exe _truckersmp-cli
+all: truckersmp-cli.exe _truckersmp-cli truckersmp-cli.bash
 
 truckersmp-cli.exe: truckersmp-cli.c
-	$(CC) $< -o $@
+	@$(CC) $< -o $@
 
 _truckersmp-cli:
-	# genzshcomp <(./truckersmp-cli --help) > _truckermp-cli
-	if which genzshcomp &> /dev/null; then \
-		./truckersmp-cli --help > helptext; \
-		genzshcomp helptext > _truckersmp-cli; \
-		rm -f helptext; \
+	@if command -v genzshcomp > /dev/null; then \
+		./truckersmp-cli --help | genzshcomp -f zsh > _truckersmp-cli; \
+	fi
+
+truckersmp-cli.bash:
+	@if command -v genzshcomp > /dev/null; then \
+		./truckersmp-cli --help | genzshcomp -f bash > truckersmp-cli.bash; \
 	fi
 
 clean:
-	rm -f truckersmp-cli.exe _truckersmp-cli
+	rm -f truckersmp-cli.exe _truckersmp-cli truckersmp-cli.bash
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,19 @@
 CC=x86_64-w64-mingw32-gcc
 
-all: truckersmp-cli.exe
+all: truckersmp-cli.exe autocompletion
 
 truckersmp-cli.exe: truckersmp-cli.c
 	$(CC) $< -o $@
 
+autocompletion:
+	# genzshcomp <(./truckersmp-cli --help) > _truckermp-cli
+	if which genzshcomp &> /dev/null; then \
+		./truckersmp-cli --help > helptext; \
+		genzshcomp helptext > _truckersmp-cli; \
+		rm -f helptext; \
+	fi
+
 clean:
-	rm -f truckersmp-cli.exe
+	rm -f truckersmp-cli.exe _truckersmp-cli
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,15 @@ CC=x86_64-w64-mingw32-gcc
 all: truckersmp-cli.exe _truckersmp-cli truckersmp-cli.bash
 
 truckersmp-cli.exe: truckersmp-cli.c
-	@$(CC) $< -o $@
+	$(CC) $< -o $@
 
 _truckersmp-cli:
-	@if command -v genzshcomp > /dev/null; then \
+	if command -v genzshcomp > /dev/null; then \
 		./truckersmp-cli --help | genzshcomp -f zsh > _truckersmp-cli; \
 	fi
 
 truckersmp-cli.bash:
-	@if command -v genzshcomp > /dev/null; then \
+	if command -v genzshcomp > /dev/null; then \
 		./truckersmp-cli --help | genzshcomp -f bash > truckersmp-cli.bash; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 CC=x86_64-w64-mingw32-gcc
 
-all: truckersmp-cli.exe autocompletion
+all: truckersmp-cli.exe _truckersmp-cli
 
 truckersmp-cli.exe: truckersmp-cli.c
 	$(CC) $< -o $@
 
-autocompletion:
+_truckersmp-cli:
 	# genzshcomp <(./truckersmp-cli --help) > _truckermp-cli
 	if which genzshcomp &> /dev/null; then \
 		./truckersmp-cli --help > helptext; \

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ $ ./truckersmp-cli -esw -x "/path/to/prefix/pfx"
 
 ### Optional
 
-* [`genzshcomp`][python-genzshcomp] to generate zsh completions
+* [`genzshcomp`][python-genzshcomp] to generate bash/zsh completions
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ $ ./truckersmp-cli -esw -x "/path/to/prefix/pfx"
     This script closes all Steam processes before acting with `steamcmd` so **starting an update with a shortcut out of
     the Steam client won't work** because Steam waits for the script and the script waits for Steam.
 
-## Dependencies
+## Runtime dependencies
 
 ### Required
 
@@ -172,6 +172,12 @@ $ ./truckersmp-cli -esw -x "/path/to/prefix/pfx"
 * `wine` as a possible replacement to Proton
 * `git` to clone this repo and self update the script
 * [`vdf`][python-vdf] to automatically detect the steam account with saved credentials
+
+## Buildtime dependencies
+
+### Optional
+
+* [`genzshcomp`][python-genzshcomp] to generate zsh completions
 
 ## Install
 
@@ -193,4 +199,5 @@ and TheUnknownNO's unofficial [TruckersMP-Launcher](https://github.com/TheUnknow
 
 Amit Malik's [article](http://securityxploded.com/dll-injection-and-hooking.php) on dll injection was also a great help.
 
+[python-genzshcomp]: https://github.com/hhatto/genzshcomp
 [python-vdf]: https://github.com/ValvePython/vdf


### PR DESCRIPTION
This will run [genzshcomp](https://github.com/hhatto/genzshcomp) when found in `$PATH` when running `make`.
It will allow tab completions when we're storing the file `_truckersmp-cli` somewhere in the `$fpath`, probably `$PREFIX/share/zsh/site-functions/_truckersmp-cli`, later through `setup.py`.

I haven't found something similar for bash.