### PR TITLE
Add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,6 @@ about: Create a report to help us improve
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 [comment]: # (Run your command with additional informational output [-v] and try to pinpoint the problem first.)
@@ -35,13 +34,12 @@ when running the command with debug output [-vv]
 
 [comment]: # (If applicable, add screenshots to help explain your problem:)
 
-![Screenshot 1](url)
 </details>
 
 ## Information
  - OS: [e.g. Ubuntu 20.04, Arch Linux]
- - Proton or Wine version: [e.g. `5.0-11`]
- - truckersmp-cli version: [e.g. `2020.0`]
+ - Proton or Wine version: [e.g. `Proton 5.0-7`, `Wine 5.9`]
+ - truckersmp-cli version: [e.g. `0.1.0`]
 
 ## Additional context
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,47 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+[comment]: # (Run your command with additional informational output [-v] and try to pinpoint the problem first.)
+
+## Describe the bug
+A clear and concise description of what the bug is.
+If needed add a step by step guide to reproduce the bug.
+
+## Expected behavior
+A clear and concise description of what you expected to happen.
+
+## Command
+~~~
+Replace this line with the command you've run [e.g. truckersmp-cli -eusp]
+~~~
+
+## Terminal output
+<details><summary>Collapsed log</summary>
+
+~~~
+Replace this line with the terminal output you're getting
+when running the command with debug output [-vv]
+~~~
+</details>
+
+## Screenshots
+<details><summary>Collapsed screenshots</summary>
+
+[comment]: # (If applicable, add screenshots to help explain your problem:)
+
+![Screenshot 1](url)
+</details>
+
+## Information
+ - OS: [e.g. Ubuntu 20.04, Arch Linux]
+ - Proton or Wine version: [e.g. `5.0-11`]
+ - truckersmp-cli version: [e.g. `2020.0`]
+
+## Additional context
+Add any other context about the problem here.


### PR DESCRIPTION
This should add an issue template which will advise the issue creator to run the script in verbose mode and paste some common information and terminal output into the report.

<details><summary>Screenshots</summary>

![Bildschirmfoto-20200529195552-1030x400](https://user-images.githubusercontent.com/1408843/83290750-745d2480-a1e7-11ea-86a6-94346030962c.png)
![Bildschirmfoto-20200529195623-1030x1267](https://user-images.githubusercontent.com/1408843/83290748-732bf780-a1e7-11ea-9f82-2e6e404a9d16.png)
![Bildschirmfoto-20200529195642-1038x1287](https://user-images.githubusercontent.com/1408843/83290744-71faca80-a1e7-11ea-98f1-18823af1c215.png)
</details>