### PR TITLE
Provide setuptools files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+*.egg-info/
+build/
+dist/
 truckersmp_cli/__pycache__/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include LICENSE
+include RELEASE
+recursive-include truckersmp_cli *.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,9 @@ packages = truckersmp_cli
 scripts = truckersmp-cli
 zip_safe = False
 
+[options.extras_require]
+optional = setuptools; vdf
+
 [options.package_data]
 truckersmp_cli =
     proton.json

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ classifiers =
 platforms = x86_64 POSIX systems
 
 [options]
-install_requires = vdf
 python_requires = >=3.3
 packages = truckersmp_cli
 scripts = truckersmp-cli

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,33 @@
+[metadata]
+name = truckersmp-cli
+version = file: RELEASE
+description = A simple launcher for TruckersMP to be used with Wine/Proton
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/lhark/truckersmp-cli
+project_urls =
+    Bug Tracker = https://github.com/lhark/truckersmp-cli/issues
+    Source Code = https://github.com/lhark/truckersmp-cli
+license = MIT
+classifiers =
+    Development Status :: 3 - Alpha
+    Intended Audience :: End Users/Desktop
+    License :: OSI Approved :: MIT License
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
+    Topic :: Games/Entertainment
+    Topic :: Games/Entertainment :: Simulation
+platforms = x86_64 POSIX systems
+
+[options]
+install_requires = vdf
+python_requires = >=3.3
+packages = truckersmp_cli
+scripts = truckersmp-cli
+zip_safe = False
+
+[options.package_data]
+truckersmp_cli =
+    proton.json
+    truckersmp-cli.exe

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+"""
+truckersmp-cli installation script.
+
+See setup.cfg for metadata and options.
+"""
+
+import setuptools
+
+setuptools.setup()


### PR DESCRIPTION
They allow us to provide our PyPI package.

This won't work until the file `RELEASE` is added to this repository, but I tested.

Project page on PyPI: https://pypi.org/project/truckersmp-cli/