### PR TITLE
GitHub Actions: Automatic uploading to PyPI

### DIFF
--- a/.github/workflows/auto_release.yaml
+++ b/.github/workflows/auto_release.yaml
@@ -9,10 +9,13 @@ on:
 
 jobs:
   release:
-    name: Publish GitHub release
+    name: Publish GitHub release and PyPI package
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
       - name: Fetch all history for all tags and branches
         run: git fetch --prune --unshallow
       - name: Set release tag
@@ -92,3 +95,13 @@ jobs:
           asset_path: output.tar.zst
           asset_name: ${{ steps.compress_files.outputs.tarfilename }}.zst
           asset_content_type: application/x-tar
+      - name: Upload package to PyPI
+        if: github.repository == 'kakurasan/truckersmp-cli'
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: |
+             pip install twine wheel
+             cd .output/*
+             python setup.py sdist bdist_wheel
+             twine upload dist/*


### PR DESCRIPTION
The automatic uploading requires a "secret" for the PyPI token,
which can be added only by repository owner (@lhark).

I can add the "secret" only to my forked repository
(kakurasan/truckersmp-cli) and tentatively I'll use
my forked repository for uploading our PyPI package.

Note: I need to keep master branch in sync with upstream.

Screenshot:
![auto-upload-pypi](https://user-images.githubusercontent.com/10556453/83935166-e63dfb00-a7f1-11ea-9ca9-16b8d7a2141a.png)

The secret `PYPI_TOKEN` is ready:
![secrets-ready](https://user-images.githubusercontent.com/10556453/83935275-22259000-a7f3-11ea-9e09-83514ac6ebf5.png)
