### PR TITLE
Implement "--self-update" option

### DIFF
--- a/truckersmp_cli/__init__.py
+++ b/truckersmp_cli/__init__.py
@@ -186,20 +186,20 @@ def perform_self_update():
 
     # unpack the archive
     logging.info("Unpacking archive {}".format(archive_url))
-    os.chdir(os.path.dirname(Dir.scriptdir))
+    topdir = os.path.dirname(Dir.scriptdir)
     try:
         with tarfile.open(fileobj=io.BytesIO(asset_archive), mode="r:xz") as f:
-            f.extractall(".")
+            f.extractall(topdir)
     except Exception as e:
         sys.exit("Failed to unpack release asset file: {}".format(e))
 
     # update files
-    archive_dir = "truckersmp-cli-" + release
+    archive_dir = os.path.join(topdir, "truckersmp-cli-" + release)
     logging.info("Removing old 'truckersmp_cli' directory")
-    shutil.rmtree("truckersmp_cli")
+    shutil.rmtree(os.path.join(topdir, "truckersmp_cli"))
     for item in glob.iglob(archive_dir + "/*"):
         logging.info("Updating {}".format(item))
-        os.replace(item, os.path.basename(item))
+        os.replace(item, os.path.join(topdir, os.path.basename(item)))
 
     # remove archive directory
     os.rmdir(archive_dir)

--- a/truckersmp_cli/__init__.py
+++ b/truckersmp_cli/__init__.py
@@ -149,10 +149,11 @@ class DowngradeHTMLParser(html.parser.HTMLParser):
 
 def perform_self_update():
     """
-    Update files to latest release.
+    Update files to latest release. Do nothing for Python package.
 
-    This function retrieves the URL to latest GitHub release asset (.tar.xz)
-    and replaces existing files with extracted files.
+    This function checks the latest GitHub release first.
+    If local version is not up-to-date, this function retrieves the URL to latest
+    GitHub release asset (.tar.xz) and replaces existing files with extracted files.
     """
     # we don't update when Python package is used
     try:
@@ -174,7 +175,7 @@ def perform_self_update():
         logging.info("Already up-to-date.")
         return
 
-    # download the release asset
+    # retrieve the release asset
     archive_url = URL.rel_tarxz_tmpl.format(release)
     logging.info("Retrieving release asset {}".format(archive_url))
     try:

--- a/truckersmp_cli/__init__.py
+++ b/truckersmp_cli/__init__.py
@@ -6,7 +6,6 @@ Licensed under MIT.
 
 import argparse
 import ctypes
-import glob
 import hashlib
 import html.parser
 import http.client
@@ -197,9 +196,17 @@ def perform_self_update():
     archive_dir = os.path.join(topdir, "truckersmp-cli-" + release)
     logging.info("Removing old 'truckersmp_cli' directory")
     shutil.rmtree(os.path.join(topdir, "truckersmp_cli"))
-    for item in glob.iglob(archive_dir + "/*"):
-        logging.info("Updating {}".format(item))
-        os.replace(item, os.path.join(topdir, os.path.basename(item)))
+    for root, dirs, files in os.walk(archive_dir):
+        for d in dirs:
+            srcpath = os.path.join(root, d)
+            dstpath = os.path.join(topdir, d)
+            logging.info("Replacing {} with {}".format(dstpath, srcpath))
+            os.replace(srcpath, dstpath)
+        for f in files:
+            srcpath = os.path.join(root, f)
+            dstpath = os.path.join(topdir, f)
+            logging.info("Replacing {} with {}".format(dstpath, srcpath))
+            os.replace(srcpath, dstpath)
 
     # remove archive directory
     os.rmdir(archive_dir)

--- a/truckersmp_cli/__init__.py
+++ b/truckersmp_cli/__init__.py
@@ -943,7 +943,7 @@ When using standard Wine you should start the windows version of Steam first.
       action="store_true")
     ap.add_argument(
       "--self-update",
-      help="""update files to the latest release.
+      help="""update files to the latest release and quit.
               Note: Python package users should use pip instead""",
       action="store_true")
     ap.add_argument(

--- a/truckersmp_cli/__init__.py
+++ b/truckersmp_cli/__init__.py
@@ -201,7 +201,7 @@ def perform_self_update():
         os.makedirs(destdir, exist_ok=True)
         for f in files:
             srcpath = os.path.join(root, f)
-            dstpath = os.path.join(topdir + inner_root, f)
+            dstpath = os.path.join(destdir, f)
             logging.info("Copying {} as {}".format(srcpath, dstpath))
             os.replace(srcpath, dstpath)
         os.rmdir(root)

--- a/truckersmp_cli/__init__.py
+++ b/truckersmp_cli/__init__.py
@@ -194,22 +194,17 @@ def perform_self_update():
 
     # update files
     archive_dir = os.path.join(topdir, "truckersmp-cli-" + release)
-    logging.info("Removing old 'truckersmp_cli' directory")
-    shutil.rmtree(os.path.join(topdir, "truckersmp_cli"))
-    for root, dirs, files in os.walk(archive_dir):
-        for d in dirs:
-            srcpath = os.path.join(root, d)
-            dstpath = os.path.join(topdir, d)
-            logging.info("Replacing {} with {}".format(dstpath, srcpath))
-            os.replace(srcpath, dstpath)
+    for root, dirs, files in os.walk(archive_dir, topdown=False):
+        inner_root = root[len(archive_dir):]
+        destdir = topdir + inner_root
+        logging.debug("Creating directory {}".format(destdir))
+        os.makedirs(destdir, exist_ok=True)
         for f in files:
             srcpath = os.path.join(root, f)
-            dstpath = os.path.join(topdir, f)
-            logging.info("Replacing {} with {}".format(dstpath, srcpath))
+            dstpath = os.path.join(topdir + inner_root, f)
+            logging.info("Copying {} as {}".format(srcpath, dstpath))
             os.replace(srcpath, dstpath)
-
-    # remove archive directory
-    os.rmdir(archive_dir)
+        os.rmdir(root)
 
     # done
     logging.info("Self update complete")

--- a/truckersmp_cli/__init__.py
+++ b/truckersmp_cli/__init__.py
@@ -151,7 +151,7 @@ def perform_self_update():
     Update files to latest release. Do nothing for Python package.
 
     This function checks the latest GitHub release first.
-    If local version is not up-to-date, this function retrieves the URL to latest
+    If local version is not up-to-date, this function retrieves the latest
     GitHub release asset (.tar.xz) and replaces existing files with extracted files.
     """
     # we don't update when Python package is used
@@ -194,7 +194,7 @@ def perform_self_update():
 
     # update files
     archive_dir = os.path.join(topdir, "truckersmp-cli-" + release)
-    for root, dirs, files in os.walk(archive_dir, topdown=False):
+    for root, _dirs, files in os.walk(archive_dir, topdown=False):
         inner_root = root[len(archive_dir):]
         destdir = topdir + inner_root
         logging.debug("Creating directory {}".format(destdir))
@@ -938,7 +938,7 @@ When using standard Wine you should start the windows version of Steam first.
       action="store_true")
     ap.add_argument(
       "--self-update",
-      help="""update files to the latest release and quit.
+      help="""update files to the latest release and quit
               Note: Python package users should use pip instead""",
       action="store_true")
     ap.add_argument(

--- a/truckersmp_cli/__init__.py
+++ b/truckersmp_cli/__init__.py
@@ -936,8 +936,7 @@ When using standard Wine you should start the windows version of Steam first.
     ap.add_argument(
       "--self-update",
       help="""update files to the latest release.
-              Note: Python package users should use
-              "pip install truckersmp-cli --upgrade" instead""",
+              Note: Python package users should use pip instead""",
       action="store_true")
     ap.add_argument(
       "--version",


### PR DESCRIPTION
Self update for release asset users and git repository users.

This implementation is simple and partially not based on my past idea.

* Don't put files into `$XDG_DATA_HOME/truckersmp-cli/`
* Unpack the archive file first, to make sure there is enough free disk space

Regarding `README.md`, it's better to add its description in #80.