### PR TITLE
start_with_wine(): Wait for Steam to be running

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Short option|Long option|Description
 (Not available)|`--self-update`|Update files to the latest release and quit
 (Not available)|`--singleplayer`|Start singleplayer game, useful for save editing, using/testing DXVK in singleplayer, etc.)
 (Not available)|`--use-wined3d`|Use OpenGL-based D3D11 instead of DXVK when using Proton
+(Not available)|`--wine-steam-dir`|Choose a directory for Windows version of Steam [Default: `C:\Program Files (x86)\Steam` in the prefix]
 (Not available)|`--version`|Print version information and quit
 
 ### Proton versions and AppIDs


### PR DESCRIPTION
This allows users not to press Enter key when Steam is ready.

Based on https://github.com/lhark/truckersmp-cli/pull/63#discussion_r423073700

Closes #58