### PR TITLE
update_game(): Support Windows version of SteamCMD for Wine

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A simple launcher for [TruckersMP][truckersmp] to play ATS or ETS2 in multiplaye
 
 _truckersmp-cli_ allows to download TruckersMP and handles starting TruckersMP through [Wine][wine] while supporting the Windows versions of [American Truck Simulator][steam:ats] and [Euro Truck Simulator 2][steam:ets2]. The [Windows version of Steam][steam:windows] should already be able to run in the same Wine prefix. The Windows versions of games can be installed or updated via [SteamCMD][steam:steamcmd].
 
-On Linux it's possible to start TruckersMP through [Proton][github:proton]. While updating all running (Linux version of) Steam processes will be stopped to prevent Steam from asking for password and guard code at Steam's next startup when Proton is used. A working [native Steam][repology:steam] installation is needed for starting through Proton.
+On Linux it's possible to start TruckersMP through [Proton][github:proton]. While updating all running Steam processes will be stopped to prevent Steam from asking for password and guard code at Steam's next startup when Proton is used. A working [native Steam][repology:steam] installation is needed for starting through Proton.
 
 If Windows version of Steam is used with Wine, password and guard code are required once when updating games.
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 A simple launcher for [TruckersMP][truckersmp] to play ATS or ETS2 in multiplayer.
 
-_truckersmp-cli_ allows to download TruckersMP and handles starting TruckersMP through [Wine][wine] while supporting the Windows versions of [American Truck Simulator][steam:ats] and [Euro Truck Simulator 2][steam:ets2]. The [Windows version of Steam][steam:windows] should already be able to run in the same Wine prefix.
+_truckersmp-cli_ allows to download TruckersMP and handles starting TruckersMP through [Wine][wine] while supporting the Windows versions of [American Truck Simulator][steam:ats] and [Euro Truck Simulator 2][steam:ets2]. The [Windows version of Steam][steam:windows] should already be able to run in the same Wine prefix. The Windows versions of games can be installed or updated via [SteamCMD][steam:steamcmd].
 
-On Linux it's possible to install and update the game's Windows versions automatically through [SteamCMD][steam:steamcmd] and start TruckersMP through [Proton][github:proton].
-While updating all running Steam processes will be stopped to prevent Steam from asking for password and guard code at Steam's next startup. A working [native Steam][repology:steam] installation is needed for starting through Proton.
+On Linux it's possible to start TruckersMP through [Proton][github:proton]. While updating all running (Linux version of) Steam processes will be stopped to prevent Steam from asking for password and guard code at Steam's next startup when Proton is used. A working [native Steam][repology:steam] installation is needed for starting through Proton.
+
+If Windows version of Steam is used with Wine, password and guard code are required once when updating games.
+
 
 ## Usage options
 
@@ -236,7 +238,7 @@ See [TruckersMP Knowledge Base][truckersmp:knowledge-base].
 
 ## Additional information
 
-* If Steam is running while SteamCMD is using the same session credentials the Steam client looses all connections and asks for the password and the guard code at the next startup. This script closes all Steam processes before acting with SteamCMD so **starting an update with a shortcut out of the Steam client won't work** because Steam waits for the script to finish and the script waits for Steam to quit.
+* If `-p` or `--proton` is specified and Linux version of Steam is running while SteamCMD is using the same session credentials the Steam client looses all connections and asks for the password and the guard code at the next startup. This script closes all Steam processes before acting with SteamCMD so **starting an update with a shortcut out of the Steam client won't work** because Steam waits for the script to finish and the script waits for Steam to quit.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,12 @@
 
 A simple launcher for [TruckersMP][truckersmp] to play ATS or ETS2 in multiplayer.
 
-_truckersmp-cli_ allows to download TruckersMP and handles starting TruckersMP through [Wine][wine] while supporting the Windows versions of [American Truck Simulator][steam:ats] and [Euro Truck Simulator 2][steam:ets2]. 
+_truckersmp-cli_ allows to download TruckersMP and handles starting TruckersMP through [Wine][wine] while supporting the Windows versions of [American Truck Simulator][steam:ats] and [Euro Truck Simulator 2][steam:ets2].
 
 The [Windows version of Steam][steam:windows] should already be able to run in the same Wine prefix.
 The Windows versions of ATS and ETS2 can be installed and updated via [SteamCMD][steam:steamcmd] while all running Steam processes will be stopped to prevent Steam from loosing connection. Your Steam password and guard code are required by SteamCMD once for this to work.
 
 On Linux it's possible to start TruckersMP through [Proton][github:proton]. A working [native Steam][repology:steam] installation is needed for this. SteamCMD can use your saved credentials for convenience.
-
 
 ## Usage options
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 A simple launcher for [TruckersMP][truckersmp] to play ATS or ETS2 in multiplayer.
 
-_truckersmp-cli_ allows to download TruckersMP and handles starting TruckersMP through [Wine][wine] while supporting the Windows versions of [American Truck Simulator][steam:ats] and [Euro Truck Simulator 2][steam:ets2]. The [Windows version of Steam][steam:windows] should already be able to run in the same Wine prefix. The Windows versions of games can be installed or updated via [SteamCMD][steam:steamcmd].
+_truckersmp-cli_ allows to download TruckersMP and handles starting TruckersMP through [Wine][wine] while supporting the Windows versions of [American Truck Simulator][steam:ats] and [Euro Truck Simulator 2][steam:ets2]. 
 
-On Linux it's possible to start TruckersMP through [Proton][github:proton]. While updating all running Steam processes will be stopped to prevent Steam from asking for password and guard code at Steam's next startup when Proton is used. A working [native Steam][repology:steam] installation is needed for starting through Proton.
+The [Windows version of Steam][steam:windows] should already be able to run in the same Wine prefix.
+The Windows versions of ATS and ETS2 can be installed and updated via [SteamCMD][steam:steamcmd] while all running Steam processes will be stopped to prevent Steam from loosing connection. Your Steam password and guard code are required by SteamCMD once for this to work.
 
-If Windows version of Steam is used with Wine, password and guard code are required once when updating games.
+On Linux it's possible to start TruckersMP through [Proton][github:proton]. A working [native Steam][repology:steam] installation is needed for this. SteamCMD can use your saved credentials for convenience.
 
 
 ## Usage options

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ See [TruckersMP Knowledge Base][truckersmp:knowledge-base].
 
 ## Additional information
 
-* If `-p` or `--proton` is specified and Linux version of Steam is running while SteamCMD is using the same session credentials the Steam client looses all connections and asks for the password and the guard code at the next startup. This script closes all Steam processes before acting with SteamCMD so **starting an update with a shortcut out of the Steam client won't work** because Steam waits for the script to finish and the script waits for Steam to quit.
+* If Steam is running while SteamCMD is being used the Steam client looses all connections and maybe asks for the password and the guard code at the next startup. This script closes all Steam processes before acting with SteamCMD so **starting an update with a shortcut out of the Steam client won't work** because Steam waits for the script to finish and the script waits for Steam to quit.
 
 ## Credits
 

--- a/truckersmp_cli/__init__.py
+++ b/truckersmp_cli/__init__.py
@@ -660,7 +660,11 @@ def get_current_steam_user():
 
     This function depends on the package "vdf".
     """
-    for path in File.loginusers_paths:
+    loginvdf_paths = File.loginusers_paths.copy()
+    # try Wine Steam directory first when Wine is used
+    if args.wine:
+        loginvdf_paths.insert(0, os.path.join(args.wine_steam_dir, File.loginvdf_inner))
+    for path in loginvdf_paths:
         try:
             with open(path) as f:
                 login_vdf = vdf.parse(f)

--- a/truckersmp_cli/__init__.py
+++ b/truckersmp_cli/__init__.py
@@ -942,13 +942,16 @@ A simple launcher for TruckersMP to play ATS or ETS2 in multiplayer.
 truckersmp-cli allows to download TruckersMP and handles starting TruckersMP through
 Wine while supporting the Windows versions of American Truck Simulator and
 Euro Truck Simulator 2. The Windows version of Steam should already be able to run
-in the same Wine prefix.
+in the same Wine prefix. The Windows versions of games can be installed or updated
+via SteamCMD.
 
-On Linux it's possible to install and update the game's Windows versions automatically
-through SteamCMD and start TruckersMP through Proton. While updating all running
-Steam processes will be stopped to prevent Steam from asking for password and
-guard code at Steam's next startup. A working native Steam installation is needed
-for starting through Proton.
+On Linux it's possible to start TruckersMP through Proton. While updating all
+running (Linux version of) Steam processes will be stopped to prevent Steam
+from asking for password and guard code at Steam's next startup when Proton is used.
+A working native Steam installation is needed for starting through Proton.
+
+If Windows version of Steam is used with Wine, password and guard code are
+required once when updating games.
 """
     epilog = "Proton AppID list:\n"
     for k, v in AppId.proton.items():

--- a/truckersmp_cli/__init__.py
+++ b/truckersmp_cli/__init__.py
@@ -840,12 +840,15 @@ def update_game():
     +force_install_dir {}
     +app_update {} validate
     +quit""".format(steamcmd, args.account, args.protondir, args.proton_appid))
-        subproc.call(
-          (steamcmd,
-           "+login", args.account,
-           "+force_install_dir", args.protondir,
-           "+app_update", str(args.proton_appid), "validate",
-           "+quit"))
+        try:
+            subproc.check_call(
+              (steamcmd,
+               "+login", args.account,
+               "+force_install_dir", args.protondir,
+               "+app_update", str(args.proton_appid), "validate",
+               "+quit"))
+        except subproc.CalledProcessError:
+            sys.exit("SteamCMD exited abnormally")
 
     # determine game branch
     branch = "public"
@@ -878,7 +881,10 @@ def update_game():
         "validate",
         "+quit",
     ]
-    subproc.call(steamcmd_cmd + steamcmd_args, env=env)
+    try:
+        subproc.check_call(steamcmd_cmd + steamcmd_args, env=env)
+    except subproc.CalledProcessError:
+        sys.exit("SteamCMD exited abnormally")
 
 
 def check_args_errors():

--- a/truckersmp_cli/__init__.py
+++ b/truckersmp_cli/__init__.py
@@ -473,8 +473,10 @@ def check_steam_process(use_proton, wine=None, env=None):
     else:
         steam_is_running = False
         argv = (wine, "winedbg", "--command", "info process")
+        env_wine = env.copy()
+        env_wine["WINEDLLOVERRIDES"] = "winex11.drv="
         try:
-            output = subproc.check_output(argv, env=env, stderr=subproc.DEVNULL)
+            output = subproc.check_output(argv, env=env_wine, stderr=subproc.DEVNULL)
             for line in output.decode("utf-8").splitlines():
                 line = line[:-1]  # strip last "'" for rindex()
                 try:

--- a/truckersmp_cli/__init__.py
+++ b/truckersmp_cli/__init__.py
@@ -973,19 +973,19 @@ def create_arg_parser():
     desc = """
 A simple launcher for TruckersMP to play ATS or ETS2 in multiplayer.
 
-truckersmp-cli allows to download TruckersMP and handles starting TruckersMP through
-Wine while supporting the Windows versions of American Truck Simulator and
-Euro Truck Simulator 2. The Windows version of Steam should already be able to run
-in the same Wine prefix. The Windows versions of games can be installed or updated
-via SteamCMD.
+truckersmp-cli allows to download TruckersMP and handles starting TruckersMP
+through Wine while supporting the Windows versions of
+American Truck Simulator and Euro Truck Simulator 2.
 
-On Linux it's possible to start TruckersMP through Proton. While updating all
-running Steam processes will be stopped to prevent Steam from asking for
-password and guard code at Steam's next startup when Proton is used.
-A working native Steam installation is needed for starting through Proton.
+The Windows version of Steam should already be able to run in the same
+Wine prefix. The Windows versions of ATS and ETS2 can be installed and updated
+via SteamCMD while all running Steam processes will be stopped
+to prevent Steam from loosing connection. Your Steam password
+and guard code are required by SteamCMD once for this to work.
 
-If Windows version of Steam is used with Wine, password and guard code are
-required once when updating games.
+On Linux it's possible to start TruckersMP through Proton.
+A working native Steam installation is needed for this.
+SteamCMD can use your saved credentials for convenience.
 """
     epilog = "Proton AppID list:\n"
     for k, v in AppId.proton.items():

--- a/truckersmp_cli/__init__.py
+++ b/truckersmp_cli/__init__.py
@@ -740,10 +740,6 @@ def update_game():
     steamcmd_prolog = ""
     steamcmd_cmd = []
     if args.proton:
-        if check_steam_process(use_proton=True):
-            logging.debug("Closing Steam")
-            subproc.call(("steam", "-shutdown"))
-
         # we don't use system SteamCMD because something goes wrong in some cases
         # see https://github.com/lhark/truckersmp-cli/issues/43
         steamcmd = os.path.join(Dir.steamcmddir, "steamcmd.sh")
@@ -804,6 +800,11 @@ def update_game():
     logging.info("SteamCMD: " + steamcmd)
 
     if args.proton:
+        # Steam needs to be closed only when using Proton
+        if check_steam_process(use_proton=True):
+            logging.debug("Closing Steam")
+            subproc.call(("steam", "-shutdown"))
+
         # download/update Proton
         os.makedirs(args.protondir, exist_ok=True)
         logging.debug("Updating Proton (AppID:{})".format(args.proton_appid))


### PR DESCRIPTION
This allows users to update games via Windows version of SteamCMD.
This is useful for non-Linux users.

~~Known issue: Password required both when executing SteamCMD ("FAILED login with invalid cached credentials") and starting Steam client~~

Note: Password required only for the first time.