### PR TITLE
GitHub Actions: Change release name to "Version"

### DIFF
--- a/.github/workflows/auto_release.yaml
+++ b/.github/workflows/auto_release.yaml
@@ -73,7 +73,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.set_release_tag.outputs.tag }}
-          release_name: Release ${{ steps.compress_files.outputs.version }}
+          release_name: Version ${{ steps.compress_files.outputs.version }}
           body: ${{ steps.generate_changelog.outputs.body }}
           draft: false
           prerelease: false


### PR DESCRIPTION
The title of each release page is "*Release Release* [version]".
This changes it to "Release Version [version]".