### PR TITLE
start_with_wine(): Append WINEDLLOVERRIDES value when disabling D3D11

### DIFF
--- a/truckersmp_cli/__init__.py
+++ b/truckersmp_cli/__init__.py
@@ -566,7 +566,10 @@ def start_with_wine():
       wine=wine,
       env=env,
     )
-    env["WINEDLLOVERRIDES"] = "d3d11=;dxgi=" if not args.enable_d3d11 else ""
+    if "WINEDLLOVERRIDES" not in env:
+        env["WINEDLLOVERRIDES"] = ""
+    if not args.enable_d3d11:
+        env["WINEDLLOVERRIDES"] += ";d3d11=;dxgi="
 
     argv = [wine, ]
     if args.singleplayer:


### PR DESCRIPTION
If `WINEDLLOVERRIDES` is already defined when starting game with Wine, it's *replaced* with `d3d11=;dxgi=` or empty.

This fixes the issue.