### PR TITLE
GitHub Actions: Add pylint checking

### DIFF
--- a/.github/workflows/check_main_script.yaml
+++ b/.github/workflows/check_main_script.yaml
@@ -31,3 +31,15 @@ jobs:
         run: pip install flake8 flake8-docstrings flake8-import-order
       - name: Check Python scripts by flake8
         run: flake8 --max-line-length=90 --show-source --statistics truckersmp-cli truckersmp_cli/*.py
+  check_by_pylint:
+    name: Check main scripts by pylint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
+      - name: Install pylint
+        run: pip install pylint
+      - name: Check Python scripts by pylint
+        run: pylint -j2 truckersmp-cli truckersmp_cli

--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+# pylint: disable=invalid-name
+
 """
 truckersmp-cli main script.
 


### PR DESCRIPTION
This adds the GitHub Actions job for pylint checking.

* pylint can be installed via `pip`
* `-j2` option (use 2 processes) makes the job faster
    * `-j0` (auto-detect the number of processors available to use) is also ok
* pylint doesn't like the name of main script `truckersmp-cli`