### PR TITLE
Add "--wine-desktop" option for DXVK tabbed-out rendering issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Short option|Long option|Description
 (Not available)|`--self-update`|Update files to the latest release and quit
 (Not available)|`--singleplayer`|Start singleplayer game, useful for save editing, using/testing DXVK in singleplayer, etc.)
 (Not available)|`--use-wined3d`|Use OpenGL-based D3D11 instead of DXVK when using Proton
+(Not available)|`--wine-desktop SIZE`|Use Wine desktop, useful to work around DXVK tabbed-out rendering issue but mouse clicking won't work in other GUI apps while game is running, SIZE must be 'WIDTHxHEIGHT' format (e.g. 1920x1080)
 (Not available)|`--wine-steam-dir`|Choose a directory for Windows version of Steam [Default: `C:\Program Files (x86)\Steam` in the prefix]
 (Not available)|`--version`|Print version information and quit
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Short option|Long option|Description
 (Not available)|`--self-update`|Update files to the latest release and quit
 (Not available)|`--singleplayer`|Start singleplayer game, useful for save editing, using/testing DXVK in singleplayer, etc.)
 (Not available)|`--use-wined3d`|Use OpenGL-based D3D11 instead of DXVK when using Proton
-(Not available)|`--wine-desktop SIZE`|Use Wine desktop, useful to work around DXVK tabbed-out rendering issue but mouse clicking won't work in other GUI apps while game is running, SIZE must be 'WIDTHxHEIGHT' format (e.g. 1920x1080)
+(Not available)|`--wine-desktop SIZE`|Use Wine desktop, work around missing TruckerMP overlay after tabbing out using DXVK, mouse clicking won't work in other GUI apps while the game is running, SIZE must be 'WIDTHxHEIGHT' format (e.g. 1920x1080)
 (Not available)|`--wine-steam-dir`|Choose a directory for Windows version of Steam [Default: `C:\Program Files (x86)\Steam` in the prefix]
 (Not available)|`--version`|Print version information and quit
 

--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -16,7 +16,7 @@ from .variables import AppId, Args, Dir
 
 def check_args_errors():
     """Check command-line arguments."""
-    # pylint: disable=too-many-branches
+    # pylint: disable=too-many-branches,too-many-statements
 
     # checks for updating and/or starting
     if not Args.update and not Args.start:
@@ -88,6 +88,18 @@ Need to download (-u) Proton?""".format(Args.protondir))
         if not Args.account:
             logging.info("Unable to find logged in steam user automatically.")
             sys.exit("Need the steam account name (-n name) to update.")
+
+    # check for Wine desktop size
+    if Args.wine_desktop:
+        split_size = Args.wine_desktop.split("x")
+        if len(split_size) != 2:
+            sys.exit("Desktop size ({}) must be 'WIDTHxHEIGHT' format".format(
+                Args.wine_desktop))
+        try:
+            if int(split_size[0]) <= 0 or int(split_size[1]) <= 0:
+                sys.exit("Desktop size is too small ({})".format(Args.wine_desktop))
+        except ValueError:
+            sys.exit("Invalid desktop width or height ({})".format(Args.wine_desktop))
 
     # info
     logging.info("AppID/GameID: %s (%s)", Args.steamid, game)
@@ -227,6 +239,12 @@ SteamCMD can use your saved credentials for convenience.
         "--use-wined3d",
         help="use OpenGL-based D3D11 instead of DXVK when using Proton",
         action="store_true")
+    parser.add_argument(
+        "--wine-desktop", metavar="SIZE", type=str,
+        help="""use Wine desktop, useful to work around
+                DXVK tabbed-out rendering issue but mouse clicking won't work
+                in other GUI apps while game is running,
+                SIZE must be 'WIDTHxHEIGHT' format (e.g. 1920x1080)""")
     parser.add_argument(
         "--wine-steam-dir", metavar="DIR", type=str,
         help="""choose a directory for Windows version of Steam

--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -96,8 +96,14 @@ Need to download (-u) Proton?""".format(Args.protondir))
             sys.exit("Desktop size ({}) must be 'WIDTHxHEIGHT' format".format(
                 Args.wine_desktop))
         try:
-            if int(split_size[0]) <= 0 or int(split_size[1]) <= 0:
-                sys.exit("Desktop size is too small ({})".format(Args.wine_desktop))
+            # if given desktop size is too small,
+            # set to 1024x768 (the lowest resolution in ETS2/ATS)
+            if int(split_size[0]) < 1024 or int(split_size[1]) < 768:
+                logging.info(
+                    "Desktop size (%s) is too small, setting size to 1024x768.",
+                    Args.wine_desktop,
+                )
+                Args.wine_desktop = "1024x768"
         except ValueError:
             sys.exit("Invalid desktop width or height ({})".format(Args.wine_desktop))
 

--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -241,10 +241,10 @@ SteamCMD can use your saved credentials for convenience.
         action="store_true")
     parser.add_argument(
         "--wine-desktop", metavar="SIZE", type=str,
-        help="""use Wine desktop, useful to work around
-                DXVK tabbed-out rendering issue but mouse clicking won't work
-                in other GUI apps while game is running,
-                SIZE must be 'WIDTHxHEIGHT' format (e.g. 1920x1080)""")
+        help="""use Wine desktop, work around missing TruckerMP overlay
+                after tabbing out using DXVK, mouse clicking won't work
+                in other GUI apps while the game is running, SIZE must be
+                'WIDTHxHEIGHT' format (e.g. 1920x1080)""")
     parser.add_argument(
         "--wine-steam-dir", metavar="DIR", type=str,
         help="""choose a directory for Windows version of Steam

--- a/truckersmp_cli/utils.py
+++ b/truckersmp_cli/utils.py
@@ -337,6 +337,40 @@ def perform_self_update():
     logging.info("Self update complete")
 
 
+def set_wine_desktop_registry(prefix, wine, enable):
+    """
+    Set Wine desktop registry.
+
+    If the 3rd argument (enable) is True, this function enables Wine desktop globally.
+    Otherwise, this function disables Wine desktop.
+
+    prefix: Path to Wine prefix to configure
+    wine: Path to Wine executable
+    enable: Whether to enable Wine desktop
+    """
+    env = os.environ.copy()
+    env["WINEDEBUG"] = "-all"
+    env["WINEPREFIX"] = prefix
+    regkey_explorer = "HKCU\\Software\\Wine\\Explorer"
+    regkey_desktops = "HKCU\\Software\\Wine\\Explorer\\Desktops"
+    if enable:
+        logging.info("Enabling Wine desktop (%s)", Args.wine_desktop)
+        subproc.call(
+            (wine, "reg", "add", regkey_explorer,
+             "/v", "Desktop", "/t", "REG_SZ", "/d", "Default", "/f"),
+            env=env)
+        subproc.call(
+            (wine, "reg", "add", regkey_desktops,
+             "/v", "Default", "/t", "REG_SZ", "/d", Args.wine_desktop, "/f"),
+            env=env)
+    else:
+        logging.info("Disabling Wine desktop")
+        subproc.call(
+            (wine, "reg", "delete", regkey_explorer, "/v", "Desktop", "/f"), env=env)
+        subproc.call(
+            (wine, "reg", "delete", regkey_desktops, "/v", "Default", "/f"), env=env)
+
+
 def wait_for_steam(use_proton, loginvdf_paths, wine=None, env=None):
     """
     Wait for Steam to be running.

--- a/truckersmp_cli/utils.py
+++ b/truckersmp_cli/utils.py
@@ -341,7 +341,8 @@ def set_wine_desktop_registry(prefix, wine, enable):
     """
     Set Wine desktop registry.
 
-    If the 3rd argument (enable) is True, this function enables Wine desktop globally.
+    If the 3rd argument (enable) is True, this function enables Wine desktop
+    for the given Wine prefix.
     Otherwise, this function disables Wine desktop.
 
     prefix: Path to Wine prefix to configure


### PR DESCRIPTION
Note that mouse clicking won't work in other GUI apps while game is running.

SIZE must be 'WIDTHxHEIGHT' format (e.g. `1920x1080`).

See also https://github.com/lhark/truckersmp-cli/issues/90#issuecomment-680889525