### PR TITLE
GitHub Actions: Checkout with "fetch-depth: 0" instead of "git fetch --prune --unshallow"

### DIFF
--- a/.github/workflows/auto_release.yaml
+++ b/.github/workflows/auto_release.yaml
@@ -13,11 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          # Fetch all history for all tags and branches
+          fetch-depth: 0
       - uses: actions/setup-python@v1
         with:
           python-version: '3.x'
-      - name: Fetch all history for all tags and branches
-        run: git fetch --prune --unshallow
       - name: Set release tag
         id: set_release_tag
         run: |


### PR DESCRIPTION
Not sure whether this fixes autorelease tags issue, but we need to change this because the document was [updated](https://github.com/actions/checkout#Fetch-all-history-for-all-tags-and-branches).