### PR TITLE
check_steam_process(): Make sure that the prefix directory exists before running winedbg

### DIFF
--- a/truckersmp_cli/utils.py
+++ b/truckersmp_cli/utils.py
@@ -136,6 +136,8 @@ def check_steam_process(use_proton, wine=None, env=None):
         argv = (wine, "winedbg", "--command", "info process")
         env_wine = env.copy()
         env_wine["WINEDLLOVERRIDES"] = "winex11.drv="
+        if "WINEPREFIX" in env_wine:
+            os.makedirs(env_wine["WINEPREFIX"], exist_ok=True)
         try:
             output = subproc.check_output(argv, env=env_wine, stderr=subproc.DEVNULL)
             for line in output.decode("utf-8").splitlines():


### PR DESCRIPTION
See https://github.com/lhark/truckersmp-cli/issues/117#issuecomment-712903652 and https://github.com/lhark/truckersmp-cli/issues/117#issuecomment-713561126

Fixes #117