### PR TITLE
Avoid switching wine versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Short option|Long option|Description
 `-w`|`--wine`|Start the game with Wine [Default on other systems if neither Proton or Wine are specified]
 `-x DIR`|`--prefixdir DIR`|Choose a different directory for the prefix [Default: `$XDG_DATA_HOME/truckersmp-cli/(Game name)/prefix`]
 (Not available)|`--activate-native-d3dcompiler-47`|Activate native 64-bit `d3dcompiler_47.dll` when starting (Needed for D3D11 renderer)
+(Not available)|`--check_windows_steam`|Check for the Windows Steam version on updating when using Proton
 (Not available)|`--disable-proton-overlay`|Disable Steam Overlay when using Proton
 (Not available)|`--self-update`|Update files to the latest release and quit
 (Not available)|`--singleplayer`|Start singleplayer game, useful for save editing, using/testing DXVK in singleplayer, etc.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Short option|Long option|Description
 `-w`|`--wine`|Start the game with Wine [Default on other systems if neither Proton or Wine are specified]
 `-x DIR`|`--prefixdir DIR`|Choose a different directory for the prefix [Default: `$XDG_DATA_HOME/truckersmp-cli/(Game name)/prefix`]
 (Not available)|`--activate-native-d3dcompiler-47`|Activate native 64-bit `d3dcompiler_47.dll` when starting (Needed for D3D11 renderer)
-(Not available)|`--check_windows_steam`|Check for the Windows Steam version on updating when using Proton
+(Not available)|`--check-windows-steam`|Check for the Windows Steam version on updating when using Proton
 (Not available)|`--disable-proton-overlay`|Disable Steam Overlay when using Proton
 (Not available)|`--self-update`|Update files to the latest release and quit
 (Not available)|`--singleplayer`|Start singleplayer game, useful for save editing, using/testing DXVK in singleplayer, etc.

--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -38,18 +38,16 @@ def check_args_errors():
     if not Args.gamedir:
         Args.gamedir = Dir.default_gamedir[game]
 
-    # checks for starting
-    if Args.start:
-        # make sure proton and wine aren't chosen at the same time
-        if Args.proton and Args.wine:
-            sys.exit("Start with Proton (-p) or Wine (-w)?")
-        elif not Args.proton and not Args.wine:
-            if platform.system() == "Linux":
-                logging.info("Platform is Linux, use Proton")
-                Args.proton = True
-            else:
-                logging.info("Platform is not Linux, use Wine")
-                Args.wine = True
+    # make sure proton and wine aren't chosen at the same time
+    if Args.proton and Args.wine:
+        sys.exit("Start/Update with Proton (-p) or Wine (-w)?")
+    elif not Args.proton and not Args.wine:
+        if platform.system() == "Linux":
+            logging.info("Platform is Linux, using Proton")
+            Args.proton = True
+        else:
+            logging.info("Platform is not Linux, using Wine")
+            Args.wine = True
 
     # make sure proton and wine are using the same default
     if Args.wine:
@@ -58,6 +56,9 @@ def check_args_errors():
             logging.debug("""Prefix directory is the default while using Wine,
 making sure it's the same directory as Proton""")
             Args.prefixdir = os.path.join(Args.prefixdir, "pfx")
+
+        # Always activate the Windows Steam check when not using Proton
+            Args.check_windows_steam = True
 
     # default Steam directory for Wine
     if not Args.wine_steam_dir:
@@ -88,10 +89,6 @@ Need to download (-u) Proton?""".format(Args.protondir))
         if not Args.account:
             logging.info("Unable to find logged in steam user automatically.")
             sys.exit("Need the steam account name (-n name) to update.")
-
-    # Always activate the Windows Steam check when not using Proton
-    if not Args.proton:
-        Args.check_windows_steam = True
 
     # check for Wine desktop size
     if Args.wine_desktop:

--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -57,8 +57,8 @@ def check_args_errors():
 making sure it's the same directory as Proton""")
             Args.prefixdir = os.path.join(Args.prefixdir, "pfx")
 
-        # Always activate the Windows Steam check when not using Proton
-            Args.check_windows_steam = True
+        # always activate the Windows Steam check when not using Proton
+        Args.check_windows_steam = True
 
     # default Steam directory for Wine
     if not Args.wine_steam_dir:

--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -89,6 +89,10 @@ Need to download (-u) Proton?""".format(Args.protondir))
             logging.info("Unable to find logged in steam user automatically.")
             sys.exit("Need the steam account name (-n name) to update.")
 
+    # Always activate the Windows Steam check when not using Proton
+    if not Args.proton:
+        Args.check_windows_steam = True
+
     # check for Wine desktop size
     if Args.wine_desktop:
         split_size = Args.wine_desktop.split("x")
@@ -226,6 +230,10 @@ SteamCMD can use your saved credentials for convenience.
         "--activate-native-d3dcompiler-47",
         help="""activate native 64-bit d3dcompiler_47.dll when starting
                 (Needed for D3D11 renderer)""",
+        action="store_true")
+    parser.add_argument(
+        "--check_windows_steam",
+        help="""check for the Windows Steam version on updating when using Proton""",
         action="store_true")
     parser.add_argument(
         "--disable-proton-overlay",

--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -232,7 +232,7 @@ SteamCMD can use your saved credentials for convenience.
                 (Needed for D3D11 renderer)""",
         action="store_true")
     parser.add_argument(
-        "--check_windows_steam",
+        "--check-windows-steam",
         help="""check for the Windows Steam version on updating when using Proton""",
         action="store_true")
     parser.add_argument(

--- a/truckersmp_cli/steamcmd.py
+++ b/truckersmp_cli/steamcmd.py
@@ -121,9 +121,9 @@ def update_game():
         logging.debug("Closing Linux version of Steam")
         subproc.call(("steam", "-shutdown"))
     # Windows version of Steam
-    if (Args.check_windows_steam and
-            wine and
-            check_steam_process(use_proton=False, wine=wine, env=env_steam)):
+    if (Args.check_windows_steam
+            and wine
+            and check_steam_process(use_proton=False, wine=wine, env=env_steam)):
         logging.debug("Closing Windows version of Steam in %s", Args.wine_steam_dir)
         subproc.call(
             (wine, os.path.join(Args.wine_steam_dir, "steam.exe"), "-shutdown"),

--- a/truckersmp_cli/steamcmd.py
+++ b/truckersmp_cli/steamcmd.py
@@ -55,14 +55,6 @@ def update_game():
     env["WINEDLLOVERRIDES"] = "winex11.drv="
 
     wine = env["WINE"] if "WINE" in env else "wine"
-    if Args.proton:
-        wine = os.path.join(Args.protondir, "dist/bin/wine")
-        env["WINEDLLPATH"] = (
-            os.path.join(Args.protondir, "dist/lib64/wine") +
-            ":" +
-            os.path.join(Args.protondir, "dist/lib/wine")
-        )
-
     os.makedirs(Dir.steamcmdpfx, exist_ok=True)
     try:
         subproc.check_call((wine, "--version"), stdout=subproc.DEVNULL, env=env)

--- a/truckersmp_cli/steamcmd.py
+++ b/truckersmp_cli/steamcmd.py
@@ -55,6 +55,14 @@ def update_game():
     env["WINEDLLOVERRIDES"] = "winex11.drv="
 
     wine = env["WINE"] if "WINE" in env else "wine"
+    if Args.proton:
+        wine = os.path.join(Args.protondir, "dist/bin/wine")
+        env["WINEDLLPATH"] = (
+            os.path.join(Args.protondir, "dist/lib64/wine") +
+            ":" +
+            os.path.join(Args.protondir, "dist/lib/wine")
+        )
+
     os.makedirs(Dir.steamcmdpfx, exist_ok=True)
     try:
         subproc.check_call((wine, "--version"), stdout=subproc.DEVNULL, env=env)

--- a/truckersmp_cli/steamcmd.py
+++ b/truckersmp_cli/steamcmd.py
@@ -56,12 +56,13 @@ def update_game():
 
     wine = env["WINE"] if "WINE" in env else "wine"
     os.makedirs(Dir.steamcmdpfx, exist_ok=True)
-    try:
-        subproc.check_call((wine, "--version"), stdout=subproc.DEVNULL, env=env)
-        logging.debug("Wine (%s) is available", wine)
-    except subproc.CalledProcessError:
-        logging.debug("Wine is not available")
-        wine = None
+    if Args.check_windows_steam:
+        try:
+            subproc.check_call((wine, "--version"), stdout=subproc.DEVNULL, env=env)
+            logging.debug("Wine (%s) is available", wine)
+        except subproc.CalledProcessError:
+            logging.debug("Wine is not available")
+            wine = None
     if Args.proton:
         # we don't use system SteamCMD because something goes wrong in some cases
         # see https://github.com/lhark/truckersmp-cli/issues/43
@@ -120,7 +121,9 @@ def update_game():
         logging.debug("Closing Linux version of Steam")
         subproc.call(("steam", "-shutdown"))
     # Windows version of Steam
-    if wine and check_steam_process(use_proton=False, wine=wine, env=env_steam):
+    if (Args.check_windows_steam and
+            wine and
+            check_steam_process(use_proton=False, wine=wine, env=env_steam)):
         logging.debug("Closing Windows version of Steam in %s", Args.wine_steam_dir)
         subproc.call(
             (wine, os.path.join(Args.wine_steam_dir, "steam.exe"), "-shutdown"),


### PR DESCRIPTION
When using Proton we should avoid using the system wine as the versions probably differs.

Calling wine with a different version than the prefix results in the whole prefix being up- or downgraded by copying all necessary files to adjust to the calling wine version. With a working proton prefix this results in a prefix upgrade on updating the game files and a downgrade afterwards when starting the game.

Let's avoid this unnecessary waiting time and hard drive stress either by using protons wine version or by reconsidering the wine call.
https://github.com/lhark/truckersmp-cli/blob/master/truckersmp_cli/steamcmd.py#L123