### PR TITLE
main.py, truckersmp-cli: Move locale.setlocale() calls to truckersmp-cli

### DIFF
--- a/truckersmp-cli
+++ b/truckersmp-cli
@@ -8,7 +8,12 @@ truckersmp-cli main script.
 This script downloads/updates games and starts games with Wine/Proton.
 """
 
+import locale
+
 from truckersmp_cli.main import main
 
+
 if __name__ == "__main__":
+    locale.setlocale(locale.LC_MESSAGES, "")
+    locale.setlocale(locale.LC_TIME, "C")
     main()

--- a/truckersmp_cli/main.py
+++ b/truckersmp_cli/main.py
@@ -5,7 +5,6 @@ Licensed under MIT.
 """
 
 import json
-import locale
 import logging
 import os
 import signal
@@ -68,8 +67,6 @@ def get_version_string():
 def main():
     """truckersmp-cli main function."""
     signal.signal(signal.SIGINT, signal.SIG_DFL)
-    locale.setlocale(locale.LC_MESSAGES, "")
-    locale.setlocale(locale.LC_TIME, "C")
 
     # load Proton AppID info from "proton.json":
     #     {"X.Y": AppID, ... , "default": "X.Y"}


### PR DESCRIPTION
`locale.setlocale()` should not be called in Python modules.

I should have fixed this in PR 73.