### PR TITLE
update_game(): Allow to skip updating Proton if Proton is already installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Short option|Long option|Description
 (Not available)|`--native-steam-dir`|Choose native Steam installation, useful only if your Steam directory is not detected automatically [Default: `auto`]
 (Not available)|`--self-update`|Update files to the latest release and quit
 (Not available)|`--singleplayer`|Start singleplayer game, useful for save editing, using/testing DXVK in singleplayer, etc.
-(Not available)|`--skip-update-proton`|Skip updating Proton when updating game with Proton enabled
+(Not available)|`--skip-update-proton`|Skip updating already-installed Proton when updating game with Proton enabled
 (Not available)|`--use-wined3d`|Use OpenGL-based D3D11 instead of DXVK when using Proton
 (Not available)|`--wine-desktop SIZE`|Use Wine desktop, work around missing TruckerMP overlay after tabbing out using DXVK, mouse clicking won't work in other GUI apps while the game is running, SIZE must be 'WIDTHxHEIGHT' format (e.g. 1920x1080)
 (Not available)|`--wine-steam-dir`|Choose a directory for Windows version of Steam [Default: `C:\Program Files (x86)\Steam` in the prefix]

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Short option|Long option|Description
 (Not available)|`--native-steam-dir`|Choose native Steam installation, useful only if your Steam directory is not detected automatically [Default: `auto`]
 (Not available)|`--self-update`|Update files to the latest release and quit
 (Not available)|`--singleplayer`|Start singleplayer game, useful for save editing, using/testing DXVK in singleplayer, etc.
+(Not available)|`--skip-update-proton`|Skip updating Proton when updating game with Proton enabled
 (Not available)|`--use-wined3d`|Use OpenGL-based D3D11 instead of DXVK when using Proton
 (Not available)|`--wine-desktop SIZE`|Use Wine desktop, work around missing TruckerMP overlay after tabbing out using DXVK, mouse clicking won't work in other GUI apps while the game is running, SIZE must be 'WIDTHxHEIGHT' format (e.g. 1920x1080)
 (Not available)|`--wine-steam-dir`|Choose a directory for Windows version of Steam [Default: `C:\Program Files (x86)\Steam` in the prefix]

--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -255,7 +255,8 @@ SteamCMD can use your saved credentials for convenience.
         action="store_true")
     parser.add_argument(
         "--skip-update-proton",
-        help="skip updating Proton when updating game with Proton enabled",
+        help="""skip updating already-installed Proton
+                when updating game with Proton enabled""",
         action="store_true")
     parser.add_argument(
         "--use-wined3d",

--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -83,12 +83,20 @@ Need to download (-u) the game?""".format(Args.gamedir))
 Need to download (-u) Proton?""".format(Args.protondir))
 
     # checks for updating
-    if Args.update and not Args.account:
-        if VDF_IS_AVAILABLE:
-            Args.account = get_current_steam_user()
+    if Args.update:
         if not Args.account:
-            logging.info("Unable to find logged in steam user automatically.")
-            sys.exit("Need the steam account name (-n name) to update.")
+            if VDF_IS_AVAILABLE:
+                Args.account = get_current_steam_user()
+            if not Args.account:
+                logging.info("Unable to find logged in steam user automatically.")
+                sys.exit("Need the steam account name (-n name) to update.")
+
+        # check whether Proton is present
+        # when "--skip-update-proton" is specified
+        if (Args.skip_update_proton
+                and not os.access(os.path.join(Args.protondir, "proton"), os.R_OK)):
+            sys.exit(
+                "'--skip-update-proton' was specified but Proton is not found.")
 
     # check for Wine desktop size
     if Args.wine_desktop:

--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -83,20 +83,12 @@ Need to download (-u) the game?""".format(Args.gamedir))
 Need to download (-u) Proton?""".format(Args.protondir))
 
     # checks for updating
-    if Args.update:
+    if Args.update and not Args.account:
+        if VDF_IS_AVAILABLE:
+            Args.account = get_current_steam_user()
         if not Args.account:
-            if VDF_IS_AVAILABLE:
-                Args.account = get_current_steam_user()
-            if not Args.account:
-                logging.info("Unable to find logged in steam user automatically.")
-                sys.exit("Need the steam account name (-n name) to update.")
-
-        # check whether Proton is present
-        # when "--skip-update-proton" is specified
-        if (Args.skip_update_proton
-                and not os.access(os.path.join(Args.protondir, "proton"), os.R_OK)):
-            sys.exit(
-                "'--skip-update-proton' was specified but Proton is not found.")
+            logging.info("Unable to find logged in steam user automatically.")
+            sys.exit("Need the steam account name (-n name) to update.")
 
     # check for Wine desktop size
     if Args.wine_desktop:

--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -254,6 +254,10 @@ SteamCMD can use your saved credentials for convenience.
                 using/testing DXVK in singleplayer, etc.""",
         action="store_true")
     parser.add_argument(
+        "--skip-update-proton",
+        help="skip updating Proton when updating game with Proton enabled",
+        action="store_true")
+    parser.add_argument(
         "--use-wined3d",
         help="use OpenGL-based D3D11 instead of DXVK when using Proton",
         action="store_true")

--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -77,10 +77,12 @@ making sure it's the same directory as Proton""")
             sys.exit("""Game not found in {}
 Need to download (-u) the game?""".format(Args.gamedir))
 
-        # check for proton
-        if not os.path.isfile(os.path.join(Args.protondir, "proton")) and Args.proton:
-            sys.exit("""Proton and no update wanted but Proton not found in {}
-Need to download (-u) Proton?""".format(Args.protondir))
+    # check for Proton availability when starting with Proton
+    if (Args.start
+            and Args.proton
+            and not os.access(os.path.join(Args.protondir, "proton"), os.R_OK)):
+        sys.exit("""Proton is not found in {}
+Run with '--update' option to install Proton""".format(Args.protondir))
 
     # checks for updating
     if Args.update and not Args.account:

--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -77,13 +77,6 @@ making sure it's the same directory as Proton""")
             sys.exit("""Game not found in {}
 Need to download (-u) the game?""".format(Args.gamedir))
 
-    # check for Proton availability when starting with Proton
-    if (Args.start
-            and Args.proton
-            and not os.access(os.path.join(Args.protondir, "proton"), os.R_OK)):
-        sys.exit("""Proton is not found in {}
-Run with '--update' option to install Proton""".format(Args.protondir))
-
     # checks for updating
     if Args.update and not Args.account:
         if VDF_IS_AVAILABLE:

--- a/truckersmp_cli/main.py
+++ b/truckersmp_cli/main.py
@@ -139,6 +139,12 @@ See {} for additional information.""".format(
 
     # start truckersmp with proton or wine
     if Args.start:
+        # check for Proton availability when starting with Proton
+        if (Args.proton
+                and not os.access(os.path.join(Args.protondir, "proton"), os.R_OK)):
+            sys.exit("""Proton is not found in {}
+Run with '--update' option to install Proton""".format(Args.protondir))
+
         if not check_libsdl2():
             sys.exit("SDL2 was not found on your system.")
         start_functions = (("Proton", start_with_proton), ("Wine", start_with_wine))

--- a/truckersmp_cli/steamcmd.py
+++ b/truckersmp_cli/steamcmd.py
@@ -33,7 +33,7 @@ def update_game():
     SteamCMD. When "--proton" is specified, this retrieves/uses
     Linux version of SteamCMD.
     """
-    # pylint: disable=too-many-branches,too-many-locals,too-many-statements
+    # pylint: disable=too-many-branches,too-many-statements
 
     steamcmd_prolog = ""
     steamcmd_cmd = []

--- a/truckersmp_cli/steamcmd.py
+++ b/truckersmp_cli/steamcmd.py
@@ -130,18 +130,9 @@ def update_game():
             env=env_steam)
 
     if Args.proton:
-        update_proton = True
         if Args.skip_update_proton:
-            # skip updating Proton only when Proton is already installed
-            try:
-                with open(os.path.join(Args.protondir, "proton")):
-                    pass
-            except OSError:
-                logging.info("Proton is not installed yet, installing Proton")
-            else:
-                logging.info("Skipping updating Proton")
-                update_proton = False
-        if update_proton:
+            logging.info("Skipping updating Proton")
+        else:
             # download/update Proton
             os.makedirs(Args.protondir, exist_ok=True)
             logging.debug("Updating Proton (AppID:%s)", Args.proton_appid)

--- a/truckersmp_cli/steamcmd.py
+++ b/truckersmp_cli/steamcmd.py
@@ -33,7 +33,7 @@ def update_game():
     SteamCMD. When "--proton" is specified, this retrieves/uses
     Linux version of SteamCMD.
     """
-    # pylint: disable=too-many-branches,too-many-statements
+    # pylint: disable=too-many-branches,too-many-locals,too-many-statements
 
     steamcmd_prolog = ""
     steamcmd_cmd = []
@@ -130,26 +130,38 @@ def update_game():
             env=env_steam)
 
     if Args.proton:
-        # download/update Proton
-        os.makedirs(Args.protondir, exist_ok=True)
-        logging.debug("Updating Proton (AppID:%s)", Args.proton_appid)
-        logging.info(
-            """Command:
+        update_proton = True
+        if Args.skip_update_proton:
+            # skip updating Proton only when Proton is already installed
+            try:
+                with open(os.path.join(Args.protondir, "proton")):
+                    pass
+            except OSError:
+                logging.info("Proton is not installed yet, installing Proton")
+            else:
+                logging.info("Skipping updating Proton")
+                update_proton = False
+        if update_proton:
+            # download/update Proton
+            os.makedirs(Args.protondir, exist_ok=True)
+            logging.debug("Updating Proton (AppID:%s)", Args.proton_appid)
+            logging.info(
+                """Command:
   %s
     +login %s
     +force_install_dir %s
     +app_update %s validate
     +quit""",
-            steamcmd, Args.account, Args.protondir, Args.proton_appid)
-        try:
-            subproc.check_call(
-                (steamcmd,
-                 "+login", Args.account,
-                 "+force_install_dir", Args.protondir,
-                 "+app_update", str(Args.proton_appid), "validate",
-                 "+quit"))
-        except subproc.CalledProcessError:
-            sys.exit("SteamCMD exited abnormally")
+                steamcmd, Args.account, Args.protondir, Args.proton_appid)
+            try:
+                subproc.check_call(
+                    (steamcmd,
+                     "+login", Args.account,
+                     "+force_install_dir", Args.protondir,
+                     "+app_update", str(Args.proton_appid), "validate",
+                     "+quit"))
+            except subproc.CalledProcessError:
+                sys.exit("SteamCMD exited abnormally")
 
     # determine game branch
     branch = determine_game_branch()


### PR DESCRIPTION
When both `--update` and `--proton` are specified, `update_game()` tries to update Proton every time.

This is not necessary when:

* User already installed Proton via Steam client (to play other Windows games) and `--protondir` is used when updating/playing
    * In this case Proton is updated via Steam client
* User knows that Proton is up-to-date
    * When user first updates ETS2 and next ATS (`truckersmp-cli --ets2 --proton --update` -> `truckersmp-cli --ats --proton --update`), the 2nd updating (for updating ATS) is redundant.

This PR adds `--skip-update-proton` option: If this option is specified and Proton is already installed, Proton is not updated.

Example: `truckersmp-cli --ets2 --proton --update && truckersmp-cli --ats --proton --update --skip-update-proton`