### PR TITLE
main.py, truckersmp.py: Remove branches that are used only for debug messages

### DIFF
--- a/truckersmp_cli/main.py
+++ b/truckersmp_cli/main.py
@@ -181,8 +181,7 @@ def start_with_proton():
     steamdir = wait_for_steam(use_proton=True, loginvdf_paths=File.loginusers_paths)
     logging.info("Steam installation directory: %s", steamdir)
 
-    if not os.path.isdir(Args.prefixdir):
-        logging.debug("Creating directory %s", Args.prefixdir)
+    logging.debug("Creating directory %s if it doesn't exist", Args.prefixdir)
     os.makedirs(Args.prefixdir, exist_ok=True)
 
     prefix = os.path.join(Args.prefixdir, "pfx")

--- a/truckersmp_cli/truckersmp.py
+++ b/truckersmp_cli/truckersmp.py
@@ -109,9 +109,8 @@ def update_mod():
     """Download missing or outdated "multiplayer mod" files."""
     # pylint: disable=too-many-branches
 
-    if not os.path.isdir(Args.moddir):
-        logging.debug("Creating directory %s", Args.moddir)
-        os.makedirs(Args.moddir, exist_ok=True)
+    logging.debug("Creating directory %s if it doesn't exist", Args.moddir)
+    os.makedirs(Args.moddir, exist_ok=True)
 
     # get the fileinfo from the server
     try:


### PR DESCRIPTION
I think the branches are not very meaningful because they're used only for printing "Creating directory /path/to/dir" debug messages.

If the directory exists, `os.makedirs("/path/to/dir", exist_ok=True)` does nothing successfully. So we don't need to use `if` to "create a directory only when it doesn't exist".